### PR TITLE
Added a property to hide the create button

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 #### Changed
 
+- Added a property to enable hiding of the "create" button in the case of a platform not having the ability to mint. [#2225](https://github.com/liteflow-labs/nft/pull/2225)
+
 #### Deprecated
 
 #### Removed

--- a/packages/components/src/Navbar/Navbar.stories.tsx
+++ b/packages/components/src/Navbar/Navbar.stories.tsx
@@ -46,3 +46,9 @@ AllowTopUp.args = {
   ...Default.args,
   allowTopUp: true,
 }
+
+export const DisableMinting = Template.bind({})
+DisableMinting.args = {
+  ...Default.args,
+  disableMinting: true,
+}

--- a/packages/components/src/Navbar/Navbar.tsx
+++ b/packages/components/src/Navbar/Navbar.tsx
@@ -118,8 +118,17 @@ const DrawerMenu: VFC<{
     addFund: () => Promise<null | undefined>
     addingFund: boolean
   }
+  disableMinting?: boolean
   signOutFn: () => void
-}> = ({ account, signOutFn, logo, router, multiLang, topUp }) => {
+}> = ({
+  account,
+  signOutFn,
+  logo,
+  router,
+  multiLang,
+  topUp,
+  disableMinting,
+}) => {
   const { isOpen, onOpen, onClose } = useDisclosure()
   const { asPath, events, query, push } = router
   const { t } = useTranslation('components')
@@ -165,9 +174,11 @@ const DrawerMenu: VFC<{
             <Link href="/explore">
               <NavItemMobile>{t('navbar.explore')}</NavItemMobile>
             </Link>
-            <Link href="/create">
-              <NavItemMobile>{t('navbar.create')}</NavItemMobile>
-            </Link>
+            {disableMinting && (
+              <Link href="/create">
+                <NavItemMobile>{t('navbar.create')}</NavItemMobile>
+              </Link>
+            )}
             {account ? (
               <>
                 <Accordion as="nav" allowMultiple>
@@ -376,6 +387,7 @@ type FormData = {
 
 const Navbar: VFC<{
   allowTopUp: boolean
+  disableMinting?: boolean
   logo?: {
     path: string
     width?: number
@@ -396,7 +408,7 @@ const Navbar: VFC<{
     networkName: string
   }
   multiLang?: MultiLang
-}> = ({ allowTopUp, logo, router, login, multiLang }) => {
+}> = ({ allowTopUp, logo, router, login, multiLang, disableMinting }) => {
   const { t } = useTranslation('components')
   const { isOpen, onOpen, onClose } = useDisclosure()
   const { account, deactivate, ready, signer } = useSession()
@@ -467,17 +479,19 @@ const Navbar: VFC<{
               {t('navbar.explore')}
             </Text>
           </Flex>
-          <Flex
-            as={Link}
-            href="/create"
-            color="brand.black"
-            align="center"
-            _hover={{ color: 'gray.500' }}
-          >
-            <Text as="span" variant="button2">
-              {t('navbar.create')}
-            </Text>
-          </Flex>
+          {disableMinting && (
+            <Flex
+              as={Link}
+              href="/create"
+              color="brand.black"
+              align="center"
+              _hover={{ color: 'gray.500' }}
+            >
+              <Text as="span" variant="button2">
+                {t('navbar.create')}
+              </Text>
+            </Flex>
+          )}
           {account && data?.account ? (
             <>
               <ActivityMenu account={account} />
@@ -543,6 +557,7 @@ const Navbar: VFC<{
             router={router}
             multiLang={multiLang}
             topUp={{ allowTopUp, addFund, addingFund }}
+            disableMinting={disableMinting}
             signOutFn={deactivate}
           />
         </Flex>

--- a/packages/components/src/Navbar/Navbar.tsx
+++ b/packages/components/src/Navbar/Navbar.tsx
@@ -174,7 +174,7 @@ const DrawerMenu: VFC<{
             <Link href="/explore">
               <NavItemMobile>{t('navbar.explore')}</NavItemMobile>
             </Link>
-            {disableMinting && (
+            {!disableMinting && (
               <Link href="/create">
                 <NavItemMobile>{t('navbar.create')}</NavItemMobile>
               </Link>
@@ -479,7 +479,7 @@ const Navbar: VFC<{
               {t('navbar.explore')}
             </Text>
           </Flex>
-          {disableMinting && (
+          {!disableMinting && (
             <Flex
               as={Link}
               href="/create"


### PR DESCRIPTION
### Project organization

- Trello card: https://trello.com/c/YkuTtNtH
- Related: https://github.com/liteflow-labs/defylabs/pull/2

### Description

This adds the functionality to hide the "create" buttons in the navbar (Desktop/Mobile) if minting is disabled on a platform.

### How to test

Test on local, add the `disableMinting={true}` to in the `Navbar` component in your Test App. See if the create buttons on desktop and mobile are removed.

### Checklist

- [ ] Update related changelogs <!-- Check [root's CHANGELOG.md](/CHANGELOG.md) to access the right changelogs -->
