### PR TITLE
Improve bundle size

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,7 +6,11 @@
 
 #### Added
 
+- Add generic type for `Select` and `TokenGrid` components [#63](https://github.com/liteflow-labs/libraries/pull/63)
+
 #### Changed
+
+- Improve bundle size by removing enums in the generated types [#63](https://github.com/liteflow-labs/libraries/pull/63)
 
 #### Deprecated
 

--- a/packages/components/codegen.yml
+++ b/packages/components/codegen.yml
@@ -11,7 +11,7 @@ generates:
       - 'typescript-react-apollo'
     config:
       avoidOptionals: true
-      enumsAsConst: true
+      enumsAsTypes: true
 config:
   scalars:
     URI: 'URI'

--- a/packages/components/src/History/HistoryList.stories.tsx
+++ b/packages/components/src/History/HistoryList.stories.tsx
@@ -1,7 +1,6 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import { ComponentMeta, ComponentStory } from '@storybook/react'
 import React from 'react'
-import { AssetHistoryAction } from '../graphql'
 import HistoryList from './HistoryList'
 
 export default {
@@ -52,15 +51,13 @@ const blockExplorer = {
 
 export const PurchaseSingle = Template.bind({})
 PurchaseSingle.args = {
-  histories: [{ action: AssetHistoryAction.Purchase, ...historySingleEdition }],
+  histories: [{ action: 'PURCHASE', ...historySingleEdition }],
   blockExplorer,
 }
 
 export const PurchaseMultiple = Template.bind({})
 PurchaseMultiple.args = {
-  histories: [
-    { action: AssetHistoryAction.Purchase, ...historyMultipleEdition },
-  ],
+  histories: [{ action: 'PURCHASE', ...historyMultipleEdition }],
   blockExplorer,
 }
 
@@ -92,7 +89,7 @@ export const ListingSingle = Template.bind({})
 ListingSingle.args = {
   histories: [
     {
-      action: AssetHistoryAction.Listing,
+      action: 'LISTING',
       ...historySingleEdition,
       transactionHash: null,
     },
@@ -103,7 +100,7 @@ export const ListingMultiple = Template.bind({})
 ListingMultiple.args = {
   histories: [
     {
-      action: AssetHistoryAction.Listing,
+      action: 'LISTING',
       ...historyMultipleEdition,
       transactionHash: null,
     },
@@ -112,14 +109,12 @@ ListingMultiple.args = {
 
 export const TransferSingle = Template.bind({})
 TransferSingle.args = {
-  histories: [{ action: AssetHistoryAction.Transfer, ...historySingleEdition }],
+  histories: [{ action: 'TRANSFER', ...historySingleEdition }],
   blockExplorer,
 }
 
 export const TransferMultiple = Template.bind({})
 TransferMultiple.args = {
-  histories: [
-    { action: AssetHistoryAction.Transfer, ...historyMultipleEdition },
-  ],
+  histories: [{ action: 'TRANSFER', ...historyMultipleEdition }],
   blockExplorer,
 }

--- a/packages/components/src/History/HistoryList.tsx
+++ b/packages/components/src/History/HistoryList.tsx
@@ -44,7 +44,7 @@ const HistoryList: VFC<IProps> = ({ histories, blockExplorer }) => {
   const { t } = useTranslation('components')
   const ListItem = (history: IProps['histories'][0]) => {
     switch (history.action) {
-      case AssetHistoryAction.Listing:
+      case 'LISTING':
         invariant(history.unitPrice, 'unitPrice is required')
         return (
           <ListingListItem
@@ -54,7 +54,7 @@ const HistoryList: VFC<IProps> = ({ histories, blockExplorer }) => {
           />
         )
 
-      case AssetHistoryAction.Purchase:
+      case 'PURCHASE':
         invariant(history.unitPrice, 'unitPrice is required')
         invariant(history.toAddress, 'toAddress is required')
         return (
@@ -67,7 +67,7 @@ const HistoryList: VFC<IProps> = ({ histories, blockExplorer }) => {
           />
         )
 
-      case AssetHistoryAction.Transfer:
+      case 'TRANSFER':
         invariant(history.toAddress, 'toAddress is required')
         if (
           history.fromAddress === '0x0000000000000000000000000000000000000000'
@@ -88,7 +88,7 @@ const HistoryList: VFC<IProps> = ({ histories, blockExplorer }) => {
           />
         )
 
-      case AssetHistoryAction.Lazymint:
+      case 'LAZYMINT':
         return <LazyMintListItem {...history} />
     }
   }

--- a/packages/components/src/Notification/Detail.stories.tsx
+++ b/packages/components/src/Notification/Detail.stories.tsx
@@ -1,6 +1,6 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react'
 import React from 'react'
-import { AccountVerificationStatus, NotificationAction } from '../graphql'
+import { AccountVerificationStatus } from '../graphql'
 import Detail from './Detail'
 
 export default {
@@ -13,7 +13,7 @@ const Template: ComponentStory<typeof Detail> = (args) => <Detail {...args} />
 const data = {
   createdAt: new Date(Date.now() - 1000 * 60 * 60 * 6), // 6 hour ago
   accountVerification: {
-    status: AccountVerificationStatus.Validated,
+    status: 'VALIDATED' as AccountVerificationStatus,
     account: {
       address: '0xfa1e52eb55a08e04c497d004bb7bd8d9ebcba9d3',
       image:
@@ -48,67 +48,67 @@ const data = {
 export const AccountVerificationValidated = Template.bind({})
 AccountVerificationValidated.args = {
   ...data,
-  action: NotificationAction.AccountVerificationValidated,
+  action: 'ACCOUNT_VERIFICATION_VALIDATED',
 }
 
 export const AuctionBidCreated = Template.bind({})
 AuctionBidCreated.args = {
   ...data,
-  action: NotificationAction.AuctionBidCreated,
+  action: 'AUCTION_BID_CREATED',
 }
 
 export const AuctionBidExpired = Template.bind({})
 AuctionBidExpired.args = {
   ...data,
-  action: NotificationAction.AuctionBidExpired,
+  action: 'AUCTION_BID_EXPIRED',
 }
 
 export const AuctionEndedNoBids = Template.bind({})
 AuctionEndedNoBids.args = {
   ...data,
-  action: NotificationAction.AuctionEndedNobids,
+  action: 'AUCTION_ENDED_NOBIDS',
 }
 
 export const AuctionEndedReservePriceBuyer = Template.bind({})
 AuctionEndedReservePriceBuyer.args = {
   ...data,
-  action: NotificationAction.AuctionEndedReservepriceBuyer,
+  action: 'AUCTION_ENDED_RESERVEPRICE_BUYER',
 }
 
 export const AuctionEndedReservePriceSeller = Template.bind({})
 AuctionEndedReservePriceSeller.args = {
   ...data,
-  action: NotificationAction.AuctionEndedReservepriceSeller,
+  action: 'AUCTION_ENDED_RESERVEPRICE_SELLER',
 }
 
 export const AuctionEndedWonBuyer = Template.bind({})
 AuctionEndedWonBuyer.args = {
   ...data,
-  action: NotificationAction.AuctionEndedWonBuyer,
+  action: 'AUCTION_ENDED_WON_BUYER',
 }
 
 export const AuctionEndedWonSeller = Template.bind({})
 AuctionEndedWonSeller.args = {
   ...data,
-  action: NotificationAction.AuctionEndedWonSeller,
+  action: 'AUCTION_ENDED_WON_SELLER',
 }
 
 export const AuctionExpired = Template.bind({})
 AuctionExpired.args = {
   ...data,
-  action: NotificationAction.AuctionExpired,
+  action: 'AUCTION_EXPIRED',
 }
 
 export const AuctionExpireSoon = Template.bind({})
 AuctionExpireSoon.args = {
   ...data,
-  action: NotificationAction.AuctionExpireSoon,
+  action: 'AUCTION_EXPIRE_SOON',
 }
 
 export const OpenBidExpiredSingleEdition = Template.bind({})
 OpenBidExpiredSingleEdition.args = {
   ...data,
-  action: NotificationAction.BidExpired,
+  action: 'BID_EXPIRED',
 }
 
 export const OpenBidExpiredMultipleEdition = Template.bind({})
@@ -119,25 +119,25 @@ OpenBidExpiredMultipleEdition.args = {
     unitPrice: '2000',
     quantity: '3',
   },
-  action: NotificationAction.BidExpired,
+  action: 'BID_EXPIRED',
 }
 
 export const DirectSaleExpired = Template.bind({})
 DirectSaleExpired.args = {
   ...data,
-  action: NotificationAction.OfferExpired,
+  action: 'OFFER_EXPIRED',
 }
 
 export const BidAccepted = Template.bind({})
 BidAccepted.args = {
   ...data,
-  action: NotificationAction.BidAccepted,
+  action: 'BID_ACCEPTED',
 }
 
 export const BidCreatedSingle = Template.bind({})
 BidCreatedSingle.args = {
   ...data,
-  action: NotificationAction.BidCreated,
+  action: 'BID_CREATED',
 }
 
 export const BidCreatedMultiple = Template.bind({})
@@ -148,13 +148,13 @@ BidCreatedMultiple.args = {
     unitPrice: '2000',
     quantity: '3',
   },
-  action: NotificationAction.BidCreated,
+  action: 'BID_CREATED',
 }
 
 export const OfferPurchasedSingle = Template.bind({})
 OfferPurchasedSingle.args = {
   ...data,
-  action: NotificationAction.OfferPurchased,
+  action: 'OFFER_PURCHASED',
 }
 
 export const OfferPurchasedMultiple = Template.bind({})
@@ -167,19 +167,19 @@ OfferPurchasedMultiple.args = {
     buyerAddress: '0xad367b82aacefed065d9a1f5ca53b2221780eb4f',
     quantity: '4',
   },
-  action: NotificationAction.OfferPurchased,
+  action: 'OFFER_PURCHASED',
 }
 
 export const OfferPurchasedMultipleFallback = Template.bind({})
 OfferPurchasedMultipleFallback.args = {
   ...data,
-  action: NotificationAction.OfferPurchased,
+  action: 'OFFER_PURCHASED',
 }
 
 export const ReferralRefereeRegistered = Template.bind({})
 ReferralRefereeRegistered.args = {
   createdAt: new Date(Date.now() - 1000 * 60 * 60 * 6), // 6 hour ago
-  action: NotificationAction.ReferralRefereeRegistered,
+  action: 'REFERRAL_REFEREE_REGISTERED',
   refereeAccount: {
     address: '0xad367b82aacefed065d9a1f5ca53b2221780eb4f',
     username: 'Patrick',

--- a/packages/components/src/Notification/Detail.tsx
+++ b/packages/components/src/Notification/Detail.tsx
@@ -94,71 +94,71 @@ export default function NotificationDetail({
       }
     | undefined = useMemo(() => {
     switch (action) {
-      case NotificationAction.AccountVerificationValidated:
+      case 'ACCOUNT_VERIFICATION_VALIDATED':
         invariant(accountVerification, 'accountVerification is required')
         return AccountVerificationValidated({ accountVerification })
 
-      case NotificationAction.OfferPurchased:
+      case 'OFFER_PURCHASED':
         invariant(offer, 'offer is required')
         return OfferPurchased({ offer, trade })
 
-      case NotificationAction.BidAccepted:
+      case 'BID_ACCEPTED':
         invariant(offer, 'offer is required')
         return BidAccepted({ offer })
 
-      case NotificationAction.BidCreated:
+      case 'BID_CREATED':
         invariant(offer, 'offer is required')
         return BidCreated({ offer })
 
-      case NotificationAction.AuctionBidCreated:
+      case 'AUCTION_BID_CREATED':
         invariant(auction, 'auction is required')
         invariant(offer, 'offer is required')
         return AuctionBidCreated({ auction, offer })
 
-      case NotificationAction.AuctionBidExpired:
+      case 'AUCTION_BID_EXPIRED':
         invariant(auction, 'auction is required')
         invariant(offer, 'offer is required')
         return AuctionBidExpired({ auction, offer })
 
-      case NotificationAction.AuctionEndedWonSeller:
+      case 'AUCTION_ENDED_WON_SELLER':
         invariant(auction, 'auction is required')
         invariant(offer, 'offer is required')
         return AuctionEndedWonSeller({ auction, offer })
 
-      case NotificationAction.AuctionEndedReservepriceSeller:
+      case 'AUCTION_ENDED_RESERVEPRICE_SELLER':
         invariant(auction, 'auction is required')
         return AuctionEndedReservePriceSeller({ auction })
 
-      case NotificationAction.AuctionEndedNobids:
+      case 'AUCTION_ENDED_NOBIDS':
         invariant(auction, 'auction is required')
         return AuctionEndedNoBids({ auction })
 
-      case NotificationAction.AuctionEndedWonBuyer:
+      case 'AUCTION_ENDED_WON_BUYER':
         invariant(auction, 'auction is required')
         return AuctionEndedWonBuyer({ auction })
 
-      case NotificationAction.AuctionEndedReservepriceBuyer:
+      case 'AUCTION_ENDED_RESERVEPRICE_BUYER':
         invariant(auction, 'auction is required')
         return AuctionEndedReservePriceBuyer({ auction })
 
-      case NotificationAction.AuctionExpireSoon:
+      case 'AUCTION_EXPIRE_SOON':
         invariant(auction, 'auction is required')
         invariant(offer, 'offer is required')
         return AuctionExpireSoon({ auction, offer })
 
-      case NotificationAction.AuctionExpired:
+      case 'AUCTION_EXPIRED':
         invariant(auction, 'auction is required')
         return AuctionExpired({ auction })
 
-      case NotificationAction.BidExpired:
+      case 'BID_EXPIRED':
         invariant(offer, 'offer is required')
         return BidExpired({ offer })
 
-      case NotificationAction.OfferExpired:
+      case 'OFFER_EXPIRED':
         invariant(offer, 'sale is required')
         return OfferExpired({ offer })
 
-      case NotificationAction.ReferralRefereeRegistered:
+      case 'REFERRAL_REFEREE_REGISTERED':
         invariant(refereeAccount, 'refereeAccount is required')
         return ReferralRefereeRegistered({ refereeAccount })
     }

--- a/packages/components/src/Offer/Form/Bid.tsx
+++ b/packages/components/src/Offer/Form/Bid.tsx
@@ -34,7 +34,6 @@ import dayjs from 'dayjs'
 import useTranslation from 'next-translate/useTranslation'
 import React, { FC, useMemo } from 'react'
 import { useForm } from 'react-hook-form'
-import { OfferType } from '../../graphql'
 import Image from '../../Image/Image'
 import CreateOfferModal from '../../Modal/CreateOffer'
 import LoginModal from '../../Modal/Login'
@@ -178,7 +177,7 @@ const OfferFormBid: FC<Props> = (props) => {
     try {
       createOfferOnOpen()
       const id = await createOffer({
-        type: OfferType.Buy,
+        type: 'BUY',
         quantity: BigNumber.from(quantity),
         unitPrice: priceUnit,
         assetId: assetId,

--- a/packages/components/src/Sales/Direct/Form.stories.tsx
+++ b/packages/components/src/Sales/Direct/Form.stories.tsx
@@ -1,7 +1,6 @@
 import { VoidSigner } from '@ethersproject/abstract-signer'
 import { ComponentMeta, ComponentStory } from '@storybook/react'
 import React from 'react'
-import { Standard } from '../../graphql'
 import Form from './Form'
 
 export default {
@@ -15,7 +14,7 @@ export const IsSingle = Template.bind({})
 IsSingle.args = {
   asset: {
     id: '1',
-    standard: Standard.Erc721,
+    standard: 'ERC721',
   },
   currencies: [
     {
@@ -39,7 +38,7 @@ export const IsMultiple = Template.bind({})
 IsMultiple.args = {
   asset: {
     id: '1',
-    standard: Standard.Erc1155,
+    standard: 'ERC1155',
   },
   currencies: [
     {

--- a/packages/components/src/Sales/Direct/Form.tsx
+++ b/packages/components/src/Sales/Direct/Form.tsx
@@ -34,7 +34,7 @@ import dayjs from 'dayjs'
 import useTranslation from 'next-translate/useTranslation'
 import React, { useMemo, VFC } from 'react'
 import { useForm } from 'react-hook-form'
-import { OfferType, Standard } from '../../graphql'
+import { Standard } from '../../graphql'
 import Image from '../../Image/Image'
 import CreateOfferModal from '../../Modal/CreateOffer'
 import Price from '../../Price/Price'
@@ -137,16 +137,13 @@ const SalesDirectForm: VFC<Props> = ({
     if (activeStep !== CreateOfferStep.INITIAL) return
     if (!asset) throw new Error('asset falsy')
     if (!currency) throw new Error('currency falsy')
-    if (
-      asset.standard !== Standard.Erc721 &&
-      asset.standard !== Standard.Erc1155
-    )
+    if (asset.standard !== 'ERC721' && asset.standard !== 'ERC1155')
       throw new Error('invalid token')
 
     try {
       onOpen()
       const id = await createAndPublishOffer({
-        type: OfferType.Sale,
+        type: 'SALE',
         quantity: BigNumber.from(quantity),
         unitPrice: priceUnit,
         assetId: asset.id,
@@ -165,7 +162,7 @@ const SalesDirectForm: VFC<Props> = ({
     }
   })
 
-  const isSingle = useMemo(() => asset.standard === Standard.Erc721, [asset])
+  const isSingle = useMemo(() => asset.standard === 'ERC721', [asset])
 
   return (
     <Stack as="form" spacing={8} onSubmit={onSubmit}>

--- a/packages/components/src/Select/Select.tsx
+++ b/packages/components/src/Select/Select.tsx
@@ -15,21 +15,21 @@ import {
   Text,
 } from '@chakra-ui/react'
 import { HiChevronDown } from '@react-icons/all-files/hi/HiChevronDown'
-import React, { FC, HTMLAttributes, useMemo } from 'react'
+import React, { HTMLAttributes, ReactElement, useMemo } from 'react'
 import { Control, Controller, FieldError } from 'react-hook-form'
 import Image from '../Image/Image'
 
-type IProps = HTMLAttributes<any> & {
+type IProps<T extends string> = HTMLAttributes<any> & {
   selectWidth?: string | number
   dropdownMaxHeight?: string | number
   label?: string
   choices: {
-    value: string
+    value: T
     label: string
     image?: string
     caption?: string
   }[]
-  value?: string
+  value?: T
   onChange?(value: string | string[] | undefined): void
   disabled?: boolean
   error?: FieldError | undefined
@@ -41,7 +41,7 @@ type IProps = HTMLAttributes<any> & {
   inlineLabel?: boolean
 }
 
-const Select: FC<IProps> = ({
+const Select = <T extends string>({
   selectWidth,
   dropdownMaxHeight,
   label,
@@ -57,7 +57,7 @@ const Select: FC<IProps> = ({
   labelInfo,
   inlineLabel,
   ...props
-}) => {
+}: IProps<T>): ReactElement => {
   const selectedChoice = useMemo(
     () => choices.find((x) => x.value === value),
     [choices, value],

--- a/packages/components/src/Token/Card.stories.tsx
+++ b/packages/components/src/Token/Card.stories.tsx
@@ -1,7 +1,6 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import { ComponentMeta, ComponentStory } from '@storybook/react'
 import React from 'react'
-import { Standard } from '../graphql'
 import Card from './Card'
 
 export default {
@@ -14,7 +13,7 @@ const Template: ComponentStory<typeof Card> = (args) => <Card {...args} />
 export const AuctionCard = Template.bind({})
 AuctionCard.args = {
   asset: {
-    standard: Standard.Erc721,
+    standard: 'ERC721',
     id: '1',
     name: 'My NFT',
     animationUrl: undefined,

--- a/packages/components/src/Token/Form/Create.tsx
+++ b/packages/components/src/Token/Form/Create.tsx
@@ -26,7 +26,6 @@ import useTranslation from 'next-translate/useTranslation'
 import React, { FC, useEffect } from 'react'
 import { useForm, useWatch } from 'react-hook-form'
 import Dropzone from '../../Dropzone/Dropzone'
-import { Standard } from '../../graphql'
 import CreateCollectibleModal from '../../Modal/CreateCollectible'
 import LoginModal from '../../Modal/Login'
 import Select from '../../Select/Select'
@@ -122,7 +121,7 @@ const TokenFormCreate: FC<Props> = ({
       if (parseFloat(data.royalties) > maxRoyalties)
         throw new Error('Royalties too high')
       const assetId = await createNFT({
-        standard: multiple ? Standard.Erc1155 : Standard.Erc721,
+        standard: multiple ? 'ERC1155' : 'ERC721',
         name: data.name,
         description: data.description,
         content: data.content,

--- a/packages/components/src/Token/Grid.stories.tsx
+++ b/packages/components/src/Token/Grid.stories.tsx
@@ -13,7 +13,7 @@ const Template: ComponentStory<typeof Grid> = (args) => <Grid {...args} />
 
 const assets = [
   {
-    standard: Standard.Erc721,
+    standard: 'ERC721' as Standard,
     id: '1',
     name: 'My NFT',
     animationUrl: undefined,
@@ -33,7 +33,7 @@ const assets = [
     hasMultiCurrency: false,
   },
   {
-    standard: Standard.Erc721,
+    standard: 'ERC721' as Standard,
     id: '1',
     name: 'My NFT',
     animationUrl: undefined,
@@ -53,7 +53,7 @@ const assets = [
     hasMultiCurrency: false,
   },
   {
-    standard: Standard.Erc721,
+    standard: 'ERC721' as Standard,
     id: '1',
     name: 'My NFT',
     animationUrl: undefined,
@@ -76,11 +76,11 @@ const assets = [
 
 const orderBy = {
   choices: [
-    { label: 'Date: Newest', value: OwnershipsOrderBy.CreatedAtDesc },
-    { label: 'Date: Oldest', value: OwnershipsOrderBy.CreatedAtAsc },
+    { label: 'Date: Newest', value: 'CREATED_AT_DESC' as OwnershipsOrderBy },
+    { label: 'Date: Oldest', value: 'CREATED_AT_ASC' as OwnershipsOrderBy },
   ],
   onSort: async (x: any) => console.log(x),
-  value: OwnershipsOrderBy.CreatedAtDesc,
+  value: 'CREATED_AT_DESC' as OwnershipsOrderBy,
 }
 
 const pagination: PaginationProps = {

--- a/packages/components/src/Token/Grid.tsx
+++ b/packages/components/src/Token/Grid.tsx
@@ -1,6 +1,7 @@
 import { Box, chakra, Flex, SimpleGrid, Stack } from '@chakra-ui/react'
 import useTranslation from 'next-translate/useTranslation'
-import React, { VFC } from 'react'
+import React from 'react'
+import { ReactElement } from 'react'
 import Empty from '../Empty/Empty'
 import type { IProp as PaginationProps } from '../Pagination/Pagination'
 import Pagination from '../Pagination/Pagination'
@@ -8,7 +9,7 @@ import Select from '../Select/Select'
 import type { Props as NFTCardProps } from './Card'
 import NFTCard from './Card'
 
-const TokenGrid: VFC<{
+type IProps<Order extends string> = {
   assets: (NFTCardProps['asset'] & {
     auction: NFTCardProps['auction']
     creator: NFTCardProps['creator']
@@ -17,15 +18,21 @@ const TokenGrid: VFC<{
     hasMultiCurrency: boolean
   })[]
   orderBy: {
-    value: string
+    value: Order
     choices: {
-      value: string
+      value: Order
       label: string
     }[]
     onSort: (orderBy: any) => Promise<void>
   }
   pagination: PaginationProps
-}> = ({ assets, orderBy, pagination }) => {
+}
+
+const TokenGrid = <Order extends string>({
+  assets,
+  orderBy,
+  pagination,
+}: IProps<Order>): ReactElement => {
   const { t } = useTranslation('components')
   if (assets.length === 0)
     return (

--- a/packages/components/src/Token/Header.stories.tsx
+++ b/packages/components/src/Token/Header.stories.tsx
@@ -1,7 +1,6 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import { ComponentMeta, ComponentStory } from '@storybook/react'
 import React from 'react'
-import { Standard } from '../graphql'
 import Header from './Header'
 
 export default {
@@ -20,7 +19,7 @@ Default.args = {
     name: 'Cryptamus®',
     saleSupply: BigNumber.from(1),
     totalSupply: BigNumber.from(1),
-    standard: Standard.Erc721,
+    standard: 'ERC721',
     animationUrl: undefined,
     unlockedContent: null,
     owned: BigNumber.from(1),

--- a/packages/components/src/Token/Header.tsx
+++ b/packages/components/src/Token/Header.tsx
@@ -57,7 +57,7 @@ const TokenHeader: VFC<Props> = ({
     () => asset.owned.gte(asset.totalSupply),
     [asset],
   )
-  const isSingle = useMemo(() => asset.standard === Standard.Erc721, [asset])
+  const isSingle = useMemo(() => asset.standard === 'ERC721', [asset])
 
   return (
     <SimpleGrid spacing={4} flex="0 0 100%" columns={{ base: 0, md: 2 }}>

--- a/packages/components/src/Token/Metadata.stories.tsx
+++ b/packages/components/src/Token/Metadata.stories.tsx
@@ -1,7 +1,6 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import { ComponentMeta, ComponentStory } from '@storybook/react'
 import React from 'react'
-import { Standard } from '../graphql'
 import Metadata from './Metadata'
 
 export default {
@@ -15,7 +14,7 @@ const Template: ComponentStory<typeof Metadata> = (args) => (
 
 export const Erc721 = Template.bind({})
 Erc721.args = {
-  standard: Standard.Erc721,
+  standard: 'ERC721',
   creator: {
     address: '0x0043a24fe3e2de5ec5c3ab0efd35b746a28b4f54',
     name: 'GENSHIRO.io',
@@ -39,7 +38,7 @@ Erc721.args = {
 
 export const Erc1155SingleOwner = Template.bind({})
 Erc1155SingleOwner.args = {
-  standard: Standard.Erc1155,
+  standard: 'ERC1155',
   creator: {
     address: '0x0043a24fe3e2de5ec5c3ab0efd35b746a28b4f54',
     name: 'GENSHIRO.io',
@@ -63,7 +62,7 @@ Erc1155SingleOwner.args = {
 
 export const Erc1155MultipleOwner = Template.bind({})
 Erc1155MultipleOwner.args = {
-  standard: Standard.Erc1155,
+  standard: 'ERC1155',
   creator: {
     address: '0x0043a24fe3e2de5ec5c3ab0efd35b746a28b4f54',
     name: 'GENSHIRO.io',
@@ -95,7 +94,7 @@ Erc1155MultipleOwner.args = {
 
 export const Erc1155MultipleOwnerMoreThanFive = Template.bind({})
 Erc1155MultipleOwnerMoreThanFive.args = {
-  standard: Standard.Erc1155,
+  standard: 'ERC1155',
   creator: {
     address: '0x0043a24fe3e2de5ec5c3ab0efd35b746a28b4f54',
     name: 'GENSHIRO.io',

--- a/packages/components/src/Token/Metadata.tsx
+++ b/packages/components/src/Token/Metadata.tsx
@@ -73,7 +73,7 @@ const TokenAsset: VFC<Props> = ({
           <OwnersModal owners={owners} />
         </Stack>
       )}
-      {standard === Standard.Erc721 && (
+      {standard === 'ERC721' && (
         <Stack spacing={3}>
           <Heading as="h5" variant="heading3" color="gray.500">
             {t('token.metadata.edition')}
@@ -86,7 +86,7 @@ const TokenAsset: VFC<Props> = ({
           </Flex>
         </Stack>
       )}
-      {standard === Standard.Erc1155 && (
+      {standard === 'ERC1155' && (
         <Stack spacing={3}>
           <Heading as="h5" variant="heading3" color="gray.500">
             {t('token.metadata.edition')}

--- a/packages/hooks/CHANGELOG.md
+++ b/packages/hooks/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 #### Changed
 
+- Improve bundle size by removing enums in the generated types [#63](https://github.com/liteflow-labs/libraries/pull/63)
+
 #### Deprecated
 
 #### Removed

--- a/packages/hooks/codegen.yml
+++ b/packages/hooks/codegen.yml
@@ -10,7 +10,7 @@ generates:
       - 'typescript-graphql-request'
     config:
       avoidOptionals: true
-      enumsAsConst: true
+      enumsAsTypes: true
 config:
   scalars:
     URI: 'URI'

--- a/packages/hooks/src/useAcceptOffer.ts
+++ b/packages/hooks/src/useAcceptOffer.ts
@@ -3,7 +3,7 @@ import { BigNumber, BigNumberish } from '@ethersproject/bignumber'
 import { gql } from 'graphql-request'
 import { useCallback, useContext, useState } from 'react'
 import { LiteflowContext } from './context'
-import { OfferType, TransactionFragment } from './graphql'
+import { TransactionFragment } from './graphql'
 import useCheckOwnership from './useCheckOwnership'
 import { convertTx } from './utils/transaction'
 
@@ -99,7 +99,7 @@ export default function useAcceptOffer(signer: Signer | undefined): [
 
         // check if operator is authorized
         let approval: TransactionFragment | null
-        if (offerWithApprovalAndFill.offer.type === OfferType.Sale) {
+        if (offerWithApprovalAndFill.offer.type === 'SALE') {
           // accepting an offer of type sale, approval is on the currency
           approval = offerWithApprovalAndFill.offer.currency.approval
         } else {
@@ -130,7 +130,7 @@ export default function useAcceptOffer(signer: Signer | undefined): [
         // determine the asset id to check ownership from
         const assetId = offerWithApprovalAndFill.offer.assetId
         const newOwner =
-          offerWithApprovalAndFill.offer.type === OfferType.Sale
+          offerWithApprovalAndFill.offer.type === 'SALE'
             ? offerWithApprovalAndFill.offer.takerAddress ||
               account.toLowerCase()
             : offerWithApprovalAndFill.offer.makerAddress

--- a/packages/hooks/src/useCreateOffer.ts
+++ b/packages/hooks/src/useCreateOffer.ts
@@ -132,7 +132,7 @@ export default function useCreateOffer(
 
         setActiveProcess(CreateOfferStep.APPROVAL_SIGNATURE)
         let approval: TransactionFragment | null
-        if (type === OfferType.Sale) {
+        if (type === 'SALE') {
           // creating a new offer of type sale, approval is on the asset
           approval = // typescript check
             asset.token.__typename === 'ERC721' ||

--- a/packages/templates/CHANGELOG.md
+++ b/packages/templates/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 #### Changed
 
+- Improve bundle size by removing enums in the generated types [#63](https://github.com/liteflow-labs/libraries/pull/63)
+
 #### Deprecated
 
 #### Removed

--- a/packages/templates/codegen.yml
+++ b/packages/templates/codegen.yml
@@ -12,7 +12,7 @@ generates:
       - 'typescript-react-apollo'
     config:
       avoidOptionals: true
-      enumsAsConst: true
+      enumsAsTypes: true
 config:
   scalars:
     URI: 'URI'

--- a/packages/templates/gen-mock.ts
+++ b/packages/templates/gen-mock.ts
@@ -1,8 +1,6 @@
 import { ApolloClient, createHttpLink, InMemoryCache } from '@apollo/client'
 import { writeFileSync } from 'fs'
 import {
-  AssetsOrderBy,
-  AuctionsOrderBy,
   BidOnAssetDocument,
   BidOnAssetQuery,
   BidOnAssetQueryVariables,
@@ -56,10 +54,6 @@ import {
   OfferForAssetDocument,
   OfferForAssetQuery,
   OfferForAssetQueryVariables,
-  OfferOpenBuysOrderBy,
-  OffersOrderBy,
-  OwnershipsOrderBy,
-  TradesOrderBy,
 } from './src/graphql'
 
 const client = new ApolloClient({
@@ -131,7 +125,7 @@ client
       now: new Date('2022-05-22T04:53:29.881Z'),
       limit: 10,
       offset: 0,
-      orderBy: AssetsOrderBy.CreatedAtDesc,
+      orderBy: 'CREATED_AT_DESC',
       filter: [],
     },
   })
@@ -197,7 +191,7 @@ client
       address: '0x6da89d36ba7cd6c371629b0724c2e17abf4049ee',
       limit: 10,
       offset: 0,
-      orderBy: OwnershipsOrderBy.CreatedAtDesc,
+      orderBy: 'CREATED_AT_DESC',
       now: new Date('2022-05-02T23:03:00.000Z'),
     },
   })
@@ -233,7 +227,7 @@ client
       address: '0x6da89d36ba7cd6c371629b0724c2e17abf4049ee',
       limit: 10,
       offset: 0,
-      orderBy: AssetsOrderBy.CreatedAtDesc,
+      orderBy: 'CREATED_AT_DESC',
       now: new Date('2022-05-02T23:03:00.000Z'),
     },
   })
@@ -268,7 +262,7 @@ client
       address: '0x6da89d36ba7cd6c371629b0724c2e17abf4049ee',
       limit: 10,
       offset: 0,
-      orderBy: AssetsOrderBy.CreatedAtDesc,
+      orderBy: 'CREATED_AT_DESC',
       now: new Date('2022-05-02T23:03:00.000Z'),
     },
   })
@@ -287,7 +281,7 @@ client
       address: '0x6da89d36ba7cd6c371629b0724c2e17abf4049ee',
       limit: 10,
       offset: 0,
-      orderBy: OfferOpenBuysOrderBy.CreatedAtDesc,
+      orderBy: 'CREATED_AT_DESC',
       now: new Date('2022-05-02T23:03:00.000Z'),
     },
   })
@@ -321,7 +315,7 @@ client
       address: '0x6da89d36ba7cd6c371629b0724c2e17abf4049ee',
       limit: 10,
       offset: 0,
-      orderBy: OfferOpenBuysOrderBy.CreatedAtDesc,
+      orderBy: 'CREATED_AT_DESC',
       now: new Date('2022-05-02T23:03:00.000Z'),
     },
   })
@@ -340,7 +334,7 @@ client
       address: '0x6da89d36ba7cd6c371629b0724c2e17abf4049ee',
       limit: 10,
       offset: 0,
-      orderBy: AuctionsOrderBy.CreatedAtDesc,
+      orderBy: 'CREATED_AT_DESC',
       now: new Date('2022-05-02T23:03:00.000Z'),
     },
   })
@@ -359,7 +353,7 @@ client
       address: '0x6da89d36ba7cd6c371629b0724c2e17abf4049ee',
       limit: 10,
       offset: 0,
-      orderBy: OffersOrderBy.CreatedAtDesc,
+      orderBy: 'CREATED_AT_DESC',
       now: new Date('2022-05-02T23:03:00.000Z'),
     },
   })
@@ -378,7 +372,7 @@ client
       address: '0x6da89d36ba7cd6c371629b0724c2e17abf4049ee',
       limit: 10,
       offset: 0,
-      orderBy: TradesOrderBy.TimestampDesc,
+      orderBy: 'TIMESTAMP_DESC',
       now: new Date('2022-05-02T23:03:00.000Z'),
     },
   })
@@ -397,7 +391,7 @@ client
       address: '0x6da89d36ba7cd6c371629b0724c2e17abf4049ee',
       limit: 10,
       offset: 0,
-      orderBy: TradesOrderBy.TimestampDesc,
+      orderBy: 'TIMESTAMP_DESC',
       now: new Date('2022-05-02T23:03:00.000Z'),
     },
   })

--- a/packages/templates/src/asset/Detail.tsx
+++ b/packages/templates/src/asset/Detail.tsx
@@ -49,7 +49,6 @@ import {
   FetchAssetIdFromTokenIdQuery,
   FetchAssetIdFromTokenIdQueryVariables,
   FetchAssetQuery,
-  Standard,
   useFetchAssetQuery,
 } from '../graphql'
 import useBlockExplorer from '../hooks/useBlockExplorer'
@@ -171,7 +170,7 @@ export const Template: VFC<
       ),
     [asset],
   )
-  const isSingle = useMemo(() => asset?.standard === Standard.Erc721, [asset])
+  const isSingle = useMemo(() => asset?.standard === 'ERC721', [asset])
 
   const tabs = [
     {

--- a/packages/templates/src/asset/Form.tsx
+++ b/packages/templates/src/asset/Form.tsx
@@ -26,10 +26,8 @@ import useTranslation from 'next-translate/useTranslation'
 import { useRouter } from 'next/router'
 import React, { useCallback, useMemo, useState } from 'react'
 import {
-  AccountVerificationStatus,
   FetchAccountDocument,
   FetchAccountQuery,
-  Standard,
   useFetchAccountQuery,
 } from '../graphql'
 import useBlockExplorer from '../hooks/useBlockExplorer'
@@ -125,7 +123,7 @@ export const Template: NextPage<
         image: imageUrlLocal || undefined,
         animationUrl: animationUrlLocal,
         name: formData?.name || '',
-        standard: multiple ? Standard.Erc1155 : Standard.Erc721,
+        standard: multiple ? 'ERC1155' : 'ERC721',
       } as NFTCardProps['asset']),
     [imageUrlLocal, animationUrlLocal, formData?.name, multiple],
   )
@@ -135,9 +133,7 @@ export const Template: NextPage<
       address: data?.account?.address || '0x',
       image: data?.account?.image || undefined,
       name: data?.account?.name || undefined,
-      verified:
-        data?.account?.verification?.status ===
-        AccountVerificationStatus.Validated,
+      verified: data?.account?.verification?.status === 'VALIDATED',
     }),
     [data?.account],
   )

--- a/packages/templates/src/asset/TypeSelector.tsx
+++ b/packages/templates/src/asset/TypeSelector.tsx
@@ -20,7 +20,6 @@ import useTranslation from 'next-translate/useTranslation'
 import { useRouter } from 'next/router'
 import React from 'react'
 import {
-  AccountVerificationStatus,
   FetchAccountVerificationStatusDocument,
   FetchAccountVerificationStatusQuery,
   FetchAccountVerificationStatusQueryVariables,
@@ -59,7 +58,7 @@ export const Template: NextPage<{
 
   if (
     restrictMintToVerifiedAccount &&
-    data?.account?.verification?.status !== AccountVerificationStatus.Validated
+    data?.account?.verification?.status !== 'VALIDATED'
   )
     return (
       <>

--- a/packages/templates/src/home/Explorer.stories.tsx
+++ b/packages/templates/src/home/Explorer.stories.tsx
@@ -1,6 +1,6 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react'
 import React from 'react'
-import { AssetsOrderBy, FetchAllErc721And1155Document } from '../graphql'
+import { FetchAllErc721And1155Document } from '../graphql'
 import * as Explorer from './Explorer'
 
 export default {
@@ -28,7 +28,7 @@ Default.args = {
     offers: [],
     currencyId: null,
   },
-  orderBy: AssetsOrderBy.CreatedAtDesc,
+  orderBy: 'CREATED_AT_DESC',
   search: null,
   traits: {
     Category: ['Category 1', 'Category 2'],

--- a/packages/templates/src/home/Explorer.tsx
+++ b/packages/templates/src/home/Explorer.tsx
@@ -225,7 +225,7 @@ export const server = (
     const offset = (page - 1) * limit
     const orderBy = Array.isArray(ctx.query.orderBy)
       ? (ctx.query.orderBy[0] as AssetsOrderBy)
-      : (ctx.query.orderBy as AssetsOrderBy) || AssetsOrderBy.CreatedAtDesc
+      : (ctx.query.orderBy as AssetsOrderBy) || 'CREATED_AT_DESC'
     const search =
       ctx.query.search && !Array.isArray(ctx.query.search)
         ? ctx.query.search
@@ -624,18 +624,18 @@ export const Template: VFC<
         </GridItem>
         <GridItem gap={6} pt={{ base: 8, lg: 0 }} colSpan={{ lg: 4, xl: 3 }}>
           <Box ml="auto" w={{ base: 'full', lg: 'min-content' }}>
-            <Select
+            <Select<AssetsOrderBy>
               label={t('explore.orderBy.label')}
               name="orderBy"
               onChange={changeOrder}
               choices={[
                 {
                   label: t('explore.orderBy.values.createdAtDesc'),
-                  value: AssetsOrderBy.CreatedAtDesc,
+                  value: 'CREATED_AT_DESC',
                 },
                 {
                   label: t('explore.orderBy.values.createdAtAsc'),
-                  value: AssetsOrderBy.CreatedAtAsc,
+                  value: 'CREATED_AT_ASC',
                 },
               ]}
               value={orderBy}

--- a/packages/templates/src/offers/Bid.tsx
+++ b/packages/templates/src/offers/Bid.tsx
@@ -22,7 +22,6 @@ import {
   BidOnAssetQuery,
   FeesForBidDocument,
   FeesForBidQuery,
-  Standard,
   useBidOnAssetQuery,
   useFeesForBidQuery,
 } from '../graphql'
@@ -245,7 +244,7 @@ export const Template: VFC<
             </>
           )}
 
-          {asset.standard === Standard.Erc721 && (
+          {asset.standard === 'ERC721' && (
             <OfferFormBid
               signer={signer}
               account={account}
@@ -263,7 +262,7 @@ export const Template: VFC<
               login={login}
             />
           )}
-          {asset.standard === Standard.Erc1155 && (
+          {asset.standard === 'ERC1155' && (
             <OfferFormBid
               signer={signer}
               account={account}

--- a/packages/templates/src/offers/Checkout.tsx
+++ b/packages/templates/src/offers/Checkout.tsx
@@ -16,13 +16,7 @@ import useTranslation from 'next-translate/useTranslation'
 import { useRouter } from 'next/router'
 import React, { useCallback, useMemo, VFC } from 'react'
 import invariant from 'ts-invariant'
-import {
-  AccountVerificationStatus,
-  CheckoutDocument,
-  CheckoutQuery,
-  Standard,
-  useCheckoutQuery,
-} from '../graphql'
+import { CheckoutDocument, CheckoutQuery, useCheckoutQuery } from '../graphql'
 import useBlockExplorer from '../hooks/useBlockExplorer'
 import useExecuteOnAccountChange from '../hooks/useExecuteOnAccountChange'
 import {
@@ -117,7 +111,7 @@ export const Template: VFC<
     () => (offer ? BigNumber.from(offer.unitPrice) : undefined),
     [offer],
   )
-  const isSingle = useMemo(() => asset?.standard === Standard.Erc721, [asset])
+  const isSingle = useMemo(() => asset?.standard === 'ERC721', [asset])
 
   const onPurchased = useCallback(async () => {
     if (!data?.offer) return
@@ -164,10 +158,7 @@ export const Template: VFC<
               address={offer.maker.address}
               image={offer.maker.image}
               name={offer.maker.name}
-              verified={
-                offer.maker.verification?.status ===
-                AccountVerificationStatus.Validated
-              }
+              verified={offer.maker.verification?.status === 'VALIDATED'}
             />
           </Stack>
 

--- a/packages/templates/src/offers/Form.tsx
+++ b/packages/templates/src/offers/Form.tsx
@@ -30,7 +30,6 @@ import {
   FeesForOfferQuery,
   OfferForAssetDocument,
   OfferForAssetQuery,
-  Standard,
   useFeesForOfferQuery,
   useOfferForAssetQuery,
 } from '../graphql'
@@ -171,7 +170,7 @@ export const Template: VFC<
         value: SaleType.TIMED_AUCTION,
         label: t('offers.form.options.values.auction'),
         icon: HiOutlineClock,
-        disabled: asset?.standard !== Standard.Erc721,
+        disabled: asset?.standard !== 'ERC721',
       },
     ],
     [asset, t],

--- a/packages/templates/src/user/Auctions.stories.tsx
+++ b/packages/templates/src/user/Auctions.stories.tsx
@@ -3,7 +3,6 @@ import { ComponentMeta, ComponentStory } from '@storybook/react'
 import React from 'react'
 import { withReactContext } from 'storybook-react-context'
 import {
-  AuctionsOrderBy,
   FetchUserAuctionsDocument,
   FetchUserAuctionsQueryVariables,
 } from '../graphql'
@@ -33,7 +32,7 @@ Default.args = {
   userAddress: '0x6da89d36ba7cd6c371629b0724c2e17abf4049ee',
   limit: 12,
   offset: 0,
-  orderBy: AuctionsOrderBy.CreatedAtDesc,
+  orderBy: 'CREATED_AT_DESC',
   limits: [12, 24, 36, 48],
   page: 1,
   explorer: {

--- a/packages/templates/src/user/Auctions.tsx
+++ b/packages/templates/src/user/Auctions.tsx
@@ -74,10 +74,7 @@ export const server = (
     invariant(userAddress, 'userAddress is falsy')
     const limit = getLimit(context, defaultLimit)
     const page = getPage(context)
-    const orderBy = getOrder<AuctionsOrderBy>(
-      context,
-      AuctionsOrderBy.CreatedAtDesc,
-    )
+    const orderBy = getOrder<AuctionsOrderBy>(context, 'CREATED_AT_DESC')
     const offset = getOffset(context, defaultLimit)
     const now = new Date()
     const { data, error } = await client.query<FetchUserAuctionsQuery>({
@@ -242,18 +239,18 @@ export const Template: VFC<
             </Link>
           </Flex>
           <Box ml="auto" w={{ base: 'full', md: 'min-content' }}>
-            <Select
+            <Select<AuctionsOrderBy>
               label={t('user.auctions.orderBy.label')}
               name="Sort by"
               onChange={changeOrder}
               choices={[
                 {
                   label: t('user.auctions.orderBy.values.createdAtDesc'),
-                  value: AuctionsOrderBy.CreatedAtDesc,
+                  value: 'CREATED_AT_DESC',
                 },
                 {
                   label: t('user.auctions.orderBy.values.createdAtAsc'),
-                  value: AuctionsOrderBy.CreatedAtAsc,
+                  value: 'CREATED_AT_ASC',
                 },
               ]}
               value={orderBy}

--- a/packages/templates/src/user/BidPlaced.stories.tsx
+++ b/packages/templates/src/user/BidPlaced.stories.tsx
@@ -3,7 +3,6 @@ import React from 'react'
 import {
   FetchUserBidsPlacedDocument,
   FetchUserBidsPlacedQueryVariables,
-  OfferOpenBuysOrderBy,
 } from '../graphql'
 import * as UserBidPlaced from './BidPlaced'
 
@@ -22,7 +21,7 @@ Default.args = {
   userAddress: '0x6da89d36ba7cd6c371629b0724c2e17abf4049ee',
   limit: 12,
   offset: 0,
-  orderBy: OfferOpenBuysOrderBy.CreatedAtDesc,
+  orderBy: 'CREATED_AT_DESC',
   limits: [12, 24, 36, 48],
   page: 1,
   explorer: {

--- a/packages/templates/src/user/BidPlaced.tsx
+++ b/packages/templates/src/user/BidPlaced.tsx
@@ -78,10 +78,7 @@ export const server = (
     invariant(userAddress, 'userAddress is falsy')
     const limit = getLimit(context, defaultLimit)
     const page = getPage(context)
-    const orderBy = getOrder<OfferOpenBuysOrderBy>(
-      context,
-      OfferOpenBuysOrderBy.CreatedAtDesc,
-    )
+    const orderBy = getOrder<OfferOpenBuysOrderBy>(context, 'CREATED_AT_DESC')
     const offset = getOffset(context, defaultLimit)
     const now = new Date()
     const { data, error } = await client.query<FetchUserBidsPlacedQuery>({
@@ -251,18 +248,18 @@ export const Template: VFC<
             </Link>
           </Flex>
           <Box ml="auto" w={{ base: 'full', md: 'min-content' }}>
-            <Select
+            <Select<OfferOpenBuysOrderBy>
               label={t('user.bid-placed.orderBy.label')}
               name="Sort by"
               onChange={changeOrder}
               choices={[
                 {
                   label: t('user.bid-placed.orderBy.values.createdAtDesc'),
-                  value: OfferOpenBuysOrderBy.CreatedAtDesc,
+                  value: 'CREATED_AT_DESC',
                 },
                 {
                   label: t('user.bid-placed.orderBy.values.createdAtAsc'),
-                  value: OfferOpenBuysOrderBy.CreatedAtAsc,
+                  value: 'CREATED_AT_ASC',
                 },
               ]}
               value={orderBy}

--- a/packages/templates/src/user/BidReceived.stories.tsx
+++ b/packages/templates/src/user/BidReceived.stories.tsx
@@ -3,7 +3,6 @@ import React from 'react'
 import {
   FetchUserBidsReceivedDocument,
   FetchUserBidsReceivedQueryVariables,
-  OfferOpenBuysOrderBy,
 } from '../graphql'
 import * as UserBidReceived from './BidReceived'
 
@@ -22,7 +21,7 @@ Default.args = {
   userAddress: '0x6da89d36ba7cd6c371629b0724c2e17abf4049ee',
   limit: 12,
   offset: 0,
-  orderBy: OfferOpenBuysOrderBy.CreatedAtDesc,
+  orderBy: 'CREATED_AT_DESC',
   limits: [12, 24, 36, 48],
   page: 1,
   explorer: {

--- a/packages/templates/src/user/BidReceived.tsx
+++ b/packages/templates/src/user/BidReceived.tsx
@@ -79,10 +79,7 @@ export const server = (
     invariant(userAddress, 'userAddress is falsy')
     const limit = getLimit(context, defaultLimit)
     const page = getPage(context)
-    const orderBy = getOrder<OfferOpenBuysOrderBy>(
-      context,
-      OfferOpenBuysOrderBy.CreatedAtDesc,
-    )
+    const orderBy = getOrder<OfferOpenBuysOrderBy>(context, 'CREATED_AT_DESC')
     const offset = getOffset(context, defaultLimit)
     const now = new Date()
     const { data, error } = await client.query<FetchUserBidsReceivedQuery>({
@@ -256,18 +253,18 @@ export const Template: VFC<
             </Link>
           </Flex>
           <Box ml="auto" w={{ base: 'full', md: 'min-content' }}>
-            <Select
+            <Select<OfferOpenBuysOrderBy>
               label={t('user.bid-received.orderBy.label')}
               name="Sort by"
               onChange={changeOrder}
               choices={[
                 {
                   label: t('user.bid-received.orderBy.values.createdAtDesc'),
-                  value: OfferOpenBuysOrderBy.CreatedAtDesc,
+                  value: 'CREATED_AT_DESC',
                 },
                 {
                   label: t('user.bid-received.orderBy.values.createdAtAsc'),
-                  value: OfferOpenBuysOrderBy.CreatedAtAsc,
+                  value: 'CREATED_AT_ASC',
                 },
               ]}
               value={orderBy}

--- a/packages/templates/src/user/CreatedAssets.stories.tsx
+++ b/packages/templates/src/user/CreatedAssets.stories.tsx
@@ -1,7 +1,6 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react'
 import React from 'react'
 import {
-  AssetsOrderBy,
   FetchCreatedAssetsDocument,
   FetchCreatedAssetsQueryVariables,
 } from '../graphql'
@@ -22,7 +21,7 @@ Default.args = {
   userAddress: '0x6da89d36ba7cd6c371629b0724c2e17abf4049ee',
   limit: 12,
   offset: 0,
-  orderBy: AssetsOrderBy.CreatedAtDesc,
+  orderBy: 'CREATED_AT_DESC',
   limits: [12, 24, 36, 48],
   page: 1,
 }

--- a/packages/templates/src/user/CreatedAssets.tsx
+++ b/packages/templates/src/user/CreatedAssets.tsx
@@ -57,7 +57,7 @@ export const server = (
 
     const limit = getLimit(ctx, defaultLimit)
     const page = getPage(ctx)
-    const orderBy = getOrder<AssetsOrderBy>(ctx, AssetsOrderBy.CreatedAtDesc)
+    const orderBy = getOrder<AssetsOrderBy>(ctx, 'CREATED_AT_DESC')
     const offset = getOffset(ctx, defaultLimit)
 
     const now = new Date()
@@ -167,18 +167,18 @@ export const Template: NextPage<Omit<Props, 'meta'> & { limits: number[] }> = ({
       }
       loginUrlForReferral={loginUrlForReferral}
     >
-      <TokenGrid
+      <TokenGrid<AssetsOrderBy>
         assets={assets}
         orderBy={{
           value: orderBy,
           choices: [
             {
               label: t('user.created-assets.orderBy.values.createdAtDesc'),
-              value: AssetsOrderBy.CreatedAtDesc,
+              value: 'CREATED_AT_DESC',
             },
             {
               label: t('user.created-assets.orderBy.values.createdAtAsc'),
-              value: AssetsOrderBy.CreatedAtAsc,
+              value: 'CREATED_AT_ASC',
             },
           ],
           onSort: changeOrder,

--- a/packages/templates/src/user/FixedPrices.stories.tsx
+++ b/packages/templates/src/user/FixedPrices.stories.tsx
@@ -5,7 +5,6 @@ import { withReactContext } from 'storybook-react-context'
 import {
   FetchUserFixedPriceDocument,
   FetchUserFixedPriceQueryVariables,
-  OffersOrderBy,
 } from '../graphql'
 import * as UserFixedPrices from './FixedPrices'
 
@@ -33,7 +32,7 @@ Default.args = {
   userAddress: '0x6da89d36ba7cd6c371629b0724c2e17abf4049ee',
   limit: 12,
   offset: 0,
-  orderBy: OffersOrderBy.CreatedAtDesc,
+  orderBy: 'CREATED_AT_DESC',
   limits: [12, 24, 36, 48],
   page: 1,
   explorer: {

--- a/packages/templates/src/user/FixedPrices.tsx
+++ b/packages/templates/src/user/FixedPrices.tsx
@@ -41,7 +41,6 @@ import invariant from 'ts-invariant'
 import {
   FetchUserFixedPriceDocument,
   FetchUserFixedPriceQuery,
-  OfferOpenBuysOrderBy,
   OffersOrderBy,
   useFetchUserFixedPriceQuery,
 } from '../graphql'
@@ -79,10 +78,7 @@ export const server = (
     invariant(userAddress, 'userAddress is falsy')
     const limit = getLimit(context, defaultLimit)
     const page = getPage(context)
-    const orderBy = getOrder<OffersOrderBy>(
-      context,
-      OffersOrderBy.CreatedAtDesc,
-    )
+    const orderBy = getOrder<OffersOrderBy>(context, 'CREATED_AT_DESC')
     const offset = getOffset(context, defaultLimit)
     const now = new Date()
     const { data, error } = await client.query<FetchUserFixedPriceQuery>({
@@ -256,26 +252,26 @@ export const Template: VFC<
             </Link>
           </Flex>
           <Box ml="auto" w={{ base: 'full', md: 'min-content' }}>
-            <Select
+            <Select<OffersOrderBy>
               label={t('user.fixed.orderBy.label')}
               name="Sort by"
               onChange={changeOrder}
               choices={[
                 {
                   label: t('user.fixed.orderBy.values.createdAtDesc'),
-                  value: OfferOpenBuysOrderBy.CreatedAtDesc,
+                  value: 'CREATED_AT_DESC',
                 },
                 {
                   label: t('user.fixed.orderBy.values.createdAtAsc'),
-                  value: OfferOpenBuysOrderBy.CreatedAtAsc,
+                  value: 'CREATED_AT_ASC',
                 },
                 {
                   label: t('user.fixed.orderBy.values.unitPriceAsc'),
-                  value: OfferOpenBuysOrderBy.UnitPriceInRefAsc,
+                  value: 'UNIT_PRICE_IN_REF_ASC',
                 },
                 {
                   label: t('user.fixed.orderBy.values.unitPriceDesc'),
-                  value: OfferOpenBuysOrderBy.UnitPriceInRefDesc,
+                  value: 'UNIT_PRICE_IN_REF_DESC',
                 },
               ]}
               value={orderBy}

--- a/packages/templates/src/user/OnSaleAssets.stories.tsx
+++ b/packages/templates/src/user/OnSaleAssets.stories.tsx
@@ -1,7 +1,6 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react'
 import React from 'react'
 import {
-  AssetsOrderBy,
   FetchOnSaleAssetsDocument,
   FetchOnSaleAssetsQueryVariables,
 } from '../graphql'
@@ -22,7 +21,7 @@ Default.args = {
   userAddress: '0x6da89d36ba7cd6c371629b0724c2e17abf4049ee',
   limit: 12,
   offset: 0,
-  orderBy: AssetsOrderBy.CreatedAtDesc,
+  orderBy: 'CREATED_AT_DESC',
   limits: [12, 24, 36, 48],
   page: 1,
 }

--- a/packages/templates/src/user/OnSaleAssets.tsx
+++ b/packages/templates/src/user/OnSaleAssets.tsx
@@ -57,7 +57,7 @@ export const server = (
 
     const limit = getLimit(ctx, defaultLimit)
     const page = getPage(ctx)
-    const orderBy = getOrder<AssetsOrderBy>(ctx, AssetsOrderBy.CreatedAtDesc)
+    const orderBy = getOrder<AssetsOrderBy>(ctx, 'CREATED_AT_DESC')
     const offset = getOffset(ctx, defaultLimit)
 
     const now = new Date()
@@ -167,18 +167,18 @@ export const Template: NextPage<Omit<Props, 'meta'> & { limits: number[] }> = ({
       }
       loginUrlForReferral={loginUrlForReferral}
     >
-      <TokenGrid
+      <TokenGrid<AssetsOrderBy>
         assets={assets}
         orderBy={{
           value: orderBy,
           choices: [
             {
               label: t('user.on-sale-assets.orderBy.values.createdAtDesc'),
-              value: AssetsOrderBy.CreatedAtDesc,
+              value: 'CREATED_AT_DESC',
             },
             {
               label: t('user.on-sale-assets.orderBy.values.createdAtAsc'),
-              value: AssetsOrderBy.CreatedAtAsc,
+              value: 'CREATED_AT_ASC',
             },
           ],
           onSort: changeOrder,

--- a/packages/templates/src/user/OwnedAssets.stories.tsx
+++ b/packages/templates/src/user/OwnedAssets.stories.tsx
@@ -3,7 +3,6 @@ import React from 'react'
 import {
   FetchOwnedAssetsDocument,
   FetchOwnedAssetsQueryVariables,
-  OwnershipsOrderBy,
 } from '../graphql'
 import * as UserOwnedAssets from './OwnedAssets'
 
@@ -22,7 +21,7 @@ Default.args = {
   userAddress: '0x6da89d36ba7cd6c371629b0724c2e17abf4049ee',
   limit: 12,
   offset: 0,
-  orderBy: OwnershipsOrderBy.CreatedAtDesc,
+  orderBy: 'CREATED_AT_DESC',
   limits: [12, 24, 36, 48],
   page: 1,
 }

--- a/packages/templates/src/user/OwnedAssets.tsx
+++ b/packages/templates/src/user/OwnedAssets.tsx
@@ -57,10 +57,7 @@ export const server = (
 
     const limit = getLimit(ctx, defaultLimit)
     const page = getPage(ctx)
-    const orderBy = getOrder<OwnershipsOrderBy>(
-      ctx,
-      OwnershipsOrderBy.CreatedAtDesc,
-    )
+    const orderBy = getOrder<OwnershipsOrderBy>(ctx, 'CREATED_AT_DESC')
     const offset = getOffset(ctx, defaultLimit)
 
     const now = new Date()
@@ -171,18 +168,18 @@ export const Template: NextPage<Omit<Props, 'meta'> & { limits: number[] }> = ({
       }
       loginUrlForReferral={loginUrlForReferral}
     >
-      <TokenGrid
+      <TokenGrid<OwnershipsOrderBy>
         assets={assets}
         orderBy={{
           value: orderBy,
           choices: [
             {
               label: t('user.owned-assets.orderBy.values.createdAtDesc'),
-              value: OwnershipsOrderBy.CreatedAtDesc,
+              value: 'CREATED_AT_DESC',
             },
             {
               label: t('user.owned-assets.orderBy.values.createdAtAsc'),
-              value: OwnershipsOrderBy.CreatedAtAsc,
+              value: 'CREATED_AT_ASC',
             },
           ],
           onSort: changeOrder,

--- a/packages/templates/src/user/TradePurchased.stories.tsx
+++ b/packages/templates/src/user/TradePurchased.stories.tsx
@@ -5,7 +5,6 @@ import { withReactContext } from 'storybook-react-context'
 import {
   FetchUserTradePurchasedDocument,
   FetchUserTradePurchasedQueryVariables,
-  TradesOrderBy,
 } from '../graphql'
 import * as UserTradePurchased from './TradePurchased'
 
@@ -33,7 +32,7 @@ Default.args = {
   userAddress: '0x6da89d36ba7cd6c371629b0724c2e17abf4049ee',
   limit: 12,
   offset: 0,
-  orderBy: TradesOrderBy.TimestampDesc,
+  orderBy: 'TIMESTAMP_DESC',
   limits: [12, 24, 36, 48],
   page: 1,
   explorer: {

--- a/packages/templates/src/user/TradePurchased.tsx
+++ b/packages/templates/src/user/TradePurchased.tsx
@@ -69,10 +69,7 @@ export const server = (
     invariant(userAddress, 'userAddress is falsy')
     const limit = getLimit(context, defaultLimit)
     const page = getPage(context)
-    const orderBy = getOrder<TradesOrderBy>(
-      context,
-      TradesOrderBy.TimestampDesc,
-    )
+    const orderBy = getOrder<TradesOrderBy>(context, 'TIMESTAMP_DESC')
     const offset = getOffset(context, defaultLimit)
     const now = new Date()
     const { data, error } = await client.query<FetchUserTradePurchasedQuery>({
@@ -212,26 +209,26 @@ export const Template: VFC<
             </Link>
           </Flex>
           <Box ml="auto" w={{ base: 'full', md: 'min-content' }}>
-            <Select
+            <Select<TradesOrderBy>
               label={t('user.trade-purchased.orderBy.label')}
               name="Sort by"
               onChange={changeOrder}
               choices={[
                 {
                   label: t('user.trade-purchased.orderBy.values.timestampDesc'),
-                  value: TradesOrderBy.TimestampDesc,
+                  value: 'TIMESTAMP_DESC',
                 },
                 {
                   label: t('user.trade-purchased.orderBy.values.timestampAsc'),
-                  value: TradesOrderBy.TimestampAsc,
+                  value: 'TIMESTAMP_ASC',
                 },
                 {
                   label: t('user.trade-purchased.orderBy.values.amountAsc'),
-                  value: TradesOrderBy.AmountInRefAsc,
+                  value: 'AMOUNT_IN_REF_ASC',
                 },
                 {
                   label: t('user.trade-purchased.orderBy.values.amountDesc'),
-                  value: TradesOrderBy.AmountInRefDesc,
+                  value: 'AMOUNT_IN_REF_DESC',
                 },
               ]}
               value={orderBy}

--- a/packages/templates/src/user/TradeSold.stories.tsx
+++ b/packages/templates/src/user/TradeSold.stories.tsx
@@ -5,7 +5,6 @@ import { withReactContext } from 'storybook-react-context'
 import {
   FetchUserTradeSoldDocument,
   FetchUserTradeSoldQueryVariables,
-  TradesOrderBy,
 } from '../graphql'
 import * as UserTradeSold from './TradeSold'
 
@@ -33,7 +32,7 @@ Default.args = {
   userAddress: '0x6da89d36ba7cd6c371629b0724c2e17abf4049ee',
   limit: 12,
   offset: 0,
-  orderBy: TradesOrderBy.TimestampDesc,
+  orderBy: 'TIMESTAMP_DESC',
   limits: [12, 24, 36, 48],
   page: 1,
   explorer: {

--- a/packages/templates/src/user/TradeSold.tsx
+++ b/packages/templates/src/user/TradeSold.tsx
@@ -69,10 +69,7 @@ export const server = (
     invariant(userAddress, 'userAddress is falsy')
     const limit = getLimit(context, defaultLimit)
     const page = getPage(context)
-    const orderBy = getOrder<TradesOrderBy>(
-      context,
-      TradesOrderBy.TimestampDesc,
-    )
+    const orderBy = getOrder<TradesOrderBy>(context, 'TIMESTAMP_DESC')
     const offset = getOffset(context, defaultLimit)
     const now = new Date()
     const { data, error } = await client.query<FetchUserTradeSoldQuery>({
@@ -213,26 +210,26 @@ export const Template: VFC<
             </Link>
           </Flex>
           <Box ml="auto" w={{ base: 'full', md: 'min-content' }}>
-            <Select
+            <Select<TradesOrderBy>
               label={t('user.trade-sold.orderBy.label')}
               name="Sort by"
               onChange={changeOrder}
               choices={[
                 {
                   label: t('user.trade-sold.orderBy.values.timestampDesc'),
-                  value: TradesOrderBy.TimestampDesc,
+                  value: 'TIMESTAMP_DESC',
                 },
                 {
                   label: t('user.trade-sold.orderBy.values.timestampAsc'),
-                  value: TradesOrderBy.TimestampAsc,
+                  value: 'TIMESTAMP_ASC',
                 },
                 {
                   label: t('user.trade-sold.orderBy.values.amountAsc'),
-                  value: TradesOrderBy.AmountInRefAsc,
+                  value: 'AMOUNT_IN_REF_ASC',
                 },
                 {
                   label: t('user.trade-sold.orderBy.values.amountDesc'),
-                  value: TradesOrderBy.AmountInRefDesc,
+                  value: 'AMOUNT_IN_REF_DESC',
                 },
               ]}
               value={orderBy}

--- a/packages/templates/src/utils/convert.ts
+++ b/packages/templates/src/utils/convert.ts
@@ -5,7 +5,6 @@ import { BigNumber } from '@ethersproject/bignumber'
 import {
   Account,
   AccountVerification,
-  AccountVerificationStatus,
   Asset,
   AssetHistory,
   AssetHistoryAction,
@@ -97,7 +96,7 @@ export const convertUser = (
   address: user?.address || defaultAddress,
   image: user?.image || null,
   name: user?.name || null,
-  verified: user?.verification?.status === AccountVerificationStatus.Validated,
+  verified: user?.verification?.status === 'VALIDATED',
 })
 
 export const convertFullUser = (
@@ -204,9 +203,7 @@ export const convertHistories = (
       ? {
           image: history.from.image,
           name: history.from.name,
-          verified:
-            history.from.verification?.status ===
-            AccountVerificationStatus.Validated,
+          verified: history.from.verification?.status === 'VALIDATED',
         }
       : null,
     toAddress: history.toAddress,
@@ -214,9 +211,7 @@ export const convertHistories = (
       ? {
           image: history.to.image,
           name: history.to.name,
-          verified:
-            history.to.verification?.status ===
-            AccountVerificationStatus.Validated,
+          verified: history.to.verification?.status === 'VALIDATED',
         }
       : null,
     currency: history.currency,
@@ -338,8 +333,7 @@ export const convertSaleFull = (
       address: sale.maker.address,
       name: sale.maker.name,
       image: sale.maker.image,
-      verified:
-        sale.maker.verification?.status === AccountVerificationStatus.Validated,
+      verified: sale.maker.verification?.status === 'VALIDATED',
     },
     expiredAt: sale.expiredAt ? new Date(sale.expiredAt) : undefined,
     availableQuantity: BigNumber.from(sale.availableQuantity),
@@ -375,8 +369,7 @@ export const convertBid = (
       address: bid.maker.address,
       image: bid.maker.image,
       name: bid.maker.name,
-      verified:
-        bid.maker.verification?.status === AccountVerificationStatus.Validated,
+      verified: bid.maker.verification?.status === 'VALIDATED',
     },
     unitPrice: BigNumber.from(bid.unitPrice),
     currency: bid.currency,


### PR DESCRIPTION
### Project organization

- Related liteflow-labs/marketplace-template#58

### Description

Reduce the bundle size by removing all the enums (99% useless) from the generated graphql file. These enums are now only present as types for typescript.

### Results

| | Before | After |
| --- | --- | --- |
| Parsed size | 4.08MB |  2.28 MB |
| Analyse | <img width="1728" alt="Screen Shot 2022-10-29 at 00 24 31" src="https://user-images.githubusercontent.com/1783126/198697237-2cd6ad2b-c070-4d16-ae22-bd4d5e56b4cc.png"> | <img width="1728" alt="Screen Shot 2022-10-29 at 00 24 40" src="https://user-images.githubusercontent.com/1783126/198697266-237f88d7-3043-4110-85e6-d503e6360b61.png"> |

##### Build before

```
Page                                       Size     First Load JS
┌ λ /                                      523 B           960 kB
├   /_app                                  0 B             831 kB
├ ○ /404                                   194 B           831 kB
├ ● /account/edit                          482 B           959 kB
├ λ /account/wallet                        478 B           959 kB
├ λ /api/fees                              0 B             831 kB
├ λ /checkout/[id]                         607 B           960 kB
├ λ /create                                538 B           960 kB
├ λ /create/[type]                         703 B           960 kB
├ λ /explore                               585 B           960 kB
├ ● /login                                 495 B           959 kB
├ λ /notification                          449 B           959 kB
├ ● /referral                              582 B           960 kB
├ λ /tokens/[id]                           582 B           960 kB
├ λ /tokens/[id]/bid                       657 B           960 kB
├ λ /tokens/[id]/offer                     613 B           960 kB
├ λ /users/[id]                            636 B           960 kB
├ λ /users/[id]/bids                       680 B           960 kB
├ λ /users/[id]/bids/placed                656 B           960 kB
├ λ /users/[id]/bids/received              657 B           960 kB
├ λ /users/[id]/created                    612 B           960 kB
├ λ /users/[id]/offers                     681 B           960 kB
├ λ /users/[id]/offers/auction             650 B           960 kB
├ λ /users/[id]/offers/fixed               656 B           960 kB
├ λ /users/[id]/on-sale                    614 B           960 kB
├ λ /users/[id]/owned                      611 B           960 kB
├ λ /users/[id]/trades                     679 B           960 kB
├ λ /users/[id]/trades/purchased           659 B           960 kB
└ λ /users/[id]/trades/sold                657 B           960 kB
+ First Load JS shared by all              831 kB
  ├ chunks/framework-4019f8cb8b6a2384.js   42.1 kB
  ├ chunks/main-58a3e64937211147.js        31.4 kB
  ├ chunks/pages/_app-52e3bc77faf69416.js  756 kB
  ├ chunks/webpack-9f954ed34dfe5ea5.js     1.92 kB
  └ css/49308b1030cce437.css               421 B
```

##### Build after
```
Page                                       Size     First Load JS
┌ λ /                                      521 B           734 kB
├   /_app                                  0 B             701 kB
├ ○ /404                                   194 B           701 kB
├ ● /account/edit                          479 B           734 kB
├ λ /account/wallet                        476 B           734 kB
├ λ /api/fees                              0 B             701 kB
├ λ /checkout/[id]                         604 B           734 kB
├ λ /create                                534 B           734 kB
├ λ /create/[type]                         700 B           734 kB
├ λ /explore                               581 B           734 kB
├ ● /login                                 492 B           734 kB
├ λ /notification                          447 B           734 kB
├ ● /referral                              578 B           734 kB
├ λ /tokens/[id]                           579 B           734 kB
├ λ /tokens/[id]/bid                       654 B           734 kB
├ λ /tokens/[id]/offer                     610 B           734 kB
├ λ /users/[id]                            631 B           734 kB
├ λ /users/[id]/bids                       676 B           734 kB
├ λ /users/[id]/bids/placed                652 B           734 kB
├ λ /users/[id]/bids/received              653 B           734 kB
├ λ /users/[id]/created                    608 B           734 kB
├ λ /users/[id]/offers                     678 B           734 kB
├ λ /users/[id]/offers/auction             647 B           734 kB
├ λ /users/[id]/offers/fixed               652 B           734 kB
├ λ /users/[id]/on-sale                    611 B           734 kB
├ λ /users/[id]/owned                      607 B           734 kB
├ λ /users/[id]/trades                     676 B           734 kB
├ λ /users/[id]/trades/purchased           655 B           734 kB
└ λ /users/[id]/trades/sold                653 B           734 kB
+ First Load JS shared by all              701 kB
  ├ chunks/framework-4019f8cb8b6a2384.js   42.1 kB
  ├ chunks/main-58a3e64937211147.js        31.4 kB
  ├ chunks/pages/_app-61237222c23f59c6.js  626 kB
  ├ chunks/webpack-5e742c8308c72bd4.js     1.97 kB
  └ css/49308b1030cce437.css               421 B
```

### Checklist

- [x] Update related changelogs <!-- Check [root's CHANGELOG.md](/CHANGELOG.md) to access the right changelogs -->
