### PR TITLE
Remove unnecessary graphql dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33436,7 +33436,6 @@
         "@web3-react/walletlink-connector": "^6.1.9",
         "bignumber.js": "^9.0.2",
         "dayjs": "^1.11.0",
-        "graphql": "^16.6.0",
         "graphql-request": "^5.0.0",
         "graphql-tag": "^2.12.6",
         "react": "^17.0.2",
@@ -33449,14 +33448,6 @@
         "@graphql-codegen/typescript-operations": "^1.18.4",
         "@nft/api-graphql": "*",
         "eslint-plugin-react-hooks": "^4.2.0"
-      }
-    },
-    "packages/hooks/node_modules/graphql": {
-      "version": "16.6.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
-      "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
-      "engines": {
-        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
     },
     "packages/templates": {
@@ -38578,18 +38569,10 @@
         "bignumber.js": "^9.0.2",
         "dayjs": "^1.11.0",
         "eslint-plugin-react-hooks": "^4.2.0",
-        "graphql": "^16.6.0",
         "graphql-request": "^5.0.0",
         "graphql-tag": "^2.12.6",
         "react": "^17.0.2",
         "react-device-detect": "^1.17.0"
-      },
-      "dependencies": {
-        "graphql": {
-          "version": "16.6.0",
-          "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
-          "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw=="
-        }
       }
     },
     "@nft/templates": {

--- a/packages/hooks/CHANGELOG.md
+++ b/packages/hooks/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 #### Changed
 
+- Remove unnecessary `graphql` dependency[#66](https://github.com/liteflow-labs/libraries/pull/66)
+
 #### Deprecated
 
 #### Removed

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -26,7 +26,6 @@
     "@web3-react/walletlink-connector": "^6.1.9",
     "bignumber.js": "^9.0.2",
     "dayjs": "^1.11.0",
-    "graphql": "^16.6.0",
     "graphql-request": "^5.0.0",
     "graphql-tag": "^2.12.6",
     "react": "^17.0.2",


### PR DESCRIPTION
### Project organization

- Closes https://github.com/liteflow-labs/libraries/issues/55

### Description

Closing https://github.com/liteflow-labs/libraries/issues/55 as most of the work has been done already while moving the repo, only the graphql lib was creating some duplications but this dependency was not even needed.

### How to test

remove all your `node_modules` then `npm i` then check that you only have the `node_modules` at the root of the repo and not inside any `packages`

### Checklist

- [x] Update related changelogs <!-- Check [root's CHANGELOG.md](/CHANGELOG.md) to access the right changelogs -->
