### PR TITLE
Ensure parsing price doesn't crash the application

### DIFF
--- a/packages/hooks/CHANGELOG.md
+++ b/packages/hooks/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 #### Fixed
 
+- Ensure that the `parsePrice` doesn't crash even with invalid input [#68](https://github.com/liteflow-labs/libraries/pull/68)
+
 #### Security
 
 ## [v1.0.0-beta.6](https://github.com/liteflow-labs/libraries/releases/tag/v1.0.0-beta.6) - 2022-10-28

--- a/packages/hooks/src/utils/parsePrice.ts
+++ b/packages/hooks/src/utils/parsePrice.ts
@@ -6,5 +6,10 @@ export const parsePrice = (
   decimals: number,
 ): BigNumber => {
   if (!price) return BigNumber.from(0)
-  return BigNumber.from(new BN(price).shiftedBy(decimals).toFixed(0))
+  try {
+    return BigNumber.from(new BN(price).shiftedBy(decimals).toFixed(0))
+  } catch {
+    console.error(`Cannot parse price ${price} as BigNumber`)
+    return BigNumber.from(0)
+  }
 }


### PR DESCRIPTION
### Project organization

- Related https://github.com/liteflow-labs/libraries/issues/23

### Description

Ensure inputs like `.1` can be set in input prices

### How to test

Check the bid form and try to input a `.2`, you should have an error in the console but the application should not crash.
For comparison, this version should crash https://storybook-components-liteflow.vercel.app/?path=/story/templates-offer-form-bid--default

### Checklist

- [x] Update related changelogs <!-- Check [root's CHANGELOG.md](/CHANGELOG.md) to access the right changelogs -->
