### PR TITLE
Fixed stories for mint list item

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 #### Fixed
 
+- Fixed a property issue causing the story for `MintListItem` Storybook story do not display. [#71](https://github.com/liteflow-labs/libraries/pull/71)
+
 #### Security
 
 ## [v1.0.0-beta.6](https://github.com/liteflow-labs/libraries/releases/tag/v1.0.0-beta.6) - 2022-10-28

--- a/packages/components/src/History/HistoryList.stories.tsx
+++ b/packages/components/src/History/HistoryList.stories.tsx
@@ -68,7 +68,7 @@ export const MintSingle = Template.bind({})
 MintSingle.args = {
   histories: [
     {
-      action: null,
+      action: 'TRANSFER',
       ...historySingleEdition,
       fromAddress: '0x0000000000000000000000000000000000000000',
     },
@@ -80,7 +80,7 @@ export const MintMultiple = Template.bind({})
 MintMultiple.args = {
   histories: [
     {
-      action: null,
+      action: 'TRANSFER',
       ...historyMultipleEdition,
       fromAddress: '0x0000000000000000000000000000000000000000',
     },


### PR DESCRIPTION
### Project organization

- Closes https://github.com/liteflow-labs/libraries/issues/70

### Description

Fix and issue where the `MintListItem` component do not render in Storybook because the `action` property is set to `null` but the component is expecting `TRANSFER` with the property `fromAddress` set to `0x0000...`

### How to test

Visit story book `HistoryList/MintSingle` and `HistoryList/MintMultiple` and they should now appear.

### Checklist

- [x] Update related changelogs
