### PR TITLE
Remove configuration for npm private package

### DIFF
--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -12,21 +12,6 @@ To use the `@nft/hooks` package you will need an app with React version `17`.
 
 ## Installation
 
-To install the library, you will need to create a `.npmrc` file at the root of your project to store the NPM access token provided to you by the Liteflow team. It should contain something like this:
-
-```bash
-//registry.npmjs.org/:_authToken=6A595196-4520-11ED-B878-0242AC120002 // Pass your NPM authToken, this is a placeholder.
-```
-
-> <em>
->   **Warning**: This token should be stored with your environment variables and
->   never exposed. It's only displayed for the purpose of this example. Check
->   the [NPM doc about
->   this](https://docs.npmjs.com/using-private-packages-in-a-ci-cd-workflow#set-the-token-as-an-environment-variable-on-the-cicd-server).
-> </em>
-
-Once this is done, you should be able to run:
-
 ```bash
 npm i @nft/hooks
 ```


### PR DESCRIPTION
Remove the instruction to connect to private libraries on NPM as now packages are public on NPM