### PR TITLE
force ownerAddress to lowercase in useCheckOwnership hook

### DIFF
--- a/packages/hooks/CHANGELOG.md
+++ b/packages/hooks/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 #### Fixed
 
+- Force `ownerAddress` to lowercase in `useCheckOwnership` hook [#85](https://github.com/liteflow-labs/liteflow-js/pull/85)
+
 #### Security
 
 ## [v1.0.0-beta.7](https://github.com/liteflow-labs/libraries/releases/tag/v1.0.0-beta.7) - 2022-11-03

--- a/packages/hooks/src/useCheckOwnership.ts
+++ b/packages/hooks/src/useCheckOwnership.ts
@@ -38,7 +38,7 @@ export default function useCheckOwnership(): {
     async (assetId: string, ownerAddress: string) => {
       const { ownerships } = await sdk.CheckOwnership({
         assetId,
-        ownerAddress,
+        ownerAddress: ownerAddress.toLowerCase(),
       })
       invariant(ownerships, ErrorMessages.OWNERSHIP_NOT_FOUND)
       if (ownerships.nodes.length === 0)


### PR DESCRIPTION
### Description

Force `ownerAddress` to lowercase in `useCheckOwnership` hook.

I check other hooks for similar issue and they are all already lowercased.

### Checklist

- [x] Update related changelogs <!-- Check [root's CHANGELOG.md](/CHANGELOG.md) to access the right changelogs -->