### PR TITLE
Update documentation to always point to the latest API doc

### DIFF
--- a/docs/pages/graphql-api/_meta.json
+++ b/docs/pages/graphql-api/_meta.json
@@ -2,7 +2,7 @@
   "index": "Introduction",
   "reference": {
     "title": "Reference",
-    "href": "https://graphdoc.io/doc/v5BuCnGrcvcIkdLh",
+    "href": "https://graphdoc.io/preview/?endpoint=https://nft-demo-bsc-testnet-4u4nk.ondigitalocean.app/graphql",
     "newWindow": true
   }
 }


### PR DESCRIPTION
### Description

The saved link from Graphdoc is actually a snapshot of the API and not the current state which means that all the recent updates are not displayed on the doc.

To fix that I changed the path to the actual endpoint, this way the doc is generated all the time and we will always have the latest version