### PR TITLE
Add / New error message added for user rejected transaction on wallet

### DIFF
--- a/packages/hooks/CHANGELOG.md
+++ b/packages/hooks/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 #### Added
 
+- Add new error message for user rejected transaction on wallet [#99](https://github.com/liteflow-labs/liteflow-js/pull/99)
+
 #### Changed
 
 #### Deprecated

--- a/packages/hooks/src/errorMessages.ts
+++ b/packages/hooks/src/errorMessages.ts
@@ -35,5 +35,5 @@ export enum ErrorMessages {
 
   POLLING_TIMEOUT = 'Polling timeout. could not check ownership',
 
-  TRANSACTION_REJECTED_BY_USER = 'You rejected the transaction',
+  TRANSACTION_REJECTED_BY_USER = 'Transaction was cancelled',
 }

--- a/packages/hooks/src/errorMessages.ts
+++ b/packages/hooks/src/errorMessages.ts
@@ -34,4 +34,6 @@ export enum ErrorMessages {
   OWNERSHIP_NOT_FOUND = 'Ownership not found',
 
   POLLING_TIMEOUT = 'Polling timeout. could not check ownership',
+
+  TRANSACTION_REJECTED_BY_USER = 'You rejected the transaction',
 }

--- a/packages/hooks/src/utils/formatError.ts
+++ b/packages/hooks/src/utils/formatError.ts
@@ -1,5 +1,9 @@
+import { ErrorMessages } from '../errorMessages'
+
 export const formatError = (error: unknown): string | undefined => {
   if (!error) return
+  if ((error as any).code === 'ACTION_REJECTED')
+    return ErrorMessages.TRANSACTION_REJECTED_BY_USER
   if ((error as any).error) return formatError((error as any).error)
   if ((error as any).data?.message) return formatError((error as any).data)
   if ((error as Error).message) return (error as Error).message


### PR DESCRIPTION
Trello card: https://trello.com/c/jw4bXigZ/452-bring-error-improvement-to-nft-hooks
Closes #98 
After this merge, could change O-mee and remove extra function which has been implemented on https://github.com/liteflow-labs/o-mee/pull/435#discussion_r1051770697