### PR TITLE
Fix import order

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,8 +19,8 @@
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-deprecation": "^1.2.1",
         "eslint-plugin-unused-imports": "^1.1.1",
-        "prettier": "^2.3.2",
-        "prettier-plugin-organize-imports": "^2.3.4",
+        "prettier": "^2.8.1",
+        "prettier-plugin-organize-imports": "^3.2.1",
         "typescript": "^4.3.4"
       },
       "engines": {
@@ -12119,9 +12119,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.1.tgz",
+      "integrity": "sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -12134,13 +12134,23 @@
       }
     },
     "node_modules/prettier-plugin-organize-imports": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-2.3.4.tgz",
-      "integrity": "sha512-R8o23sf5iVL/U71h9SFUdhdOEPsi3nm42FD/oDYIZ2PQa4TNWWuWecxln6jlIQzpZTDMUeO1NicJP6lLn2TtRw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-3.2.1.tgz",
+      "integrity": "sha512-bty7C2Ecard5EOXirtzeCAqj4FU4epeuWrQt/Z+sh8UVEpBlBZ3m3KNPz2kFu7KgRTQx/C9o4/TdquPD1jOqjQ==",
       "dev": true,
       "peerDependencies": {
+        "@volar/vue-language-plugin-pug": "^1.0.4",
+        "@volar/vue-typescript": "^1.0.4",
         "prettier": ">=2.0",
         "typescript": ">=2.9"
+      },
+      "peerDependenciesMeta": {
+        "@volar/vue-language-plugin-pug": {
+          "optional": true
+        },
+        "@volar/vue-typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/proc-log": {
@@ -24069,15 +24079,15 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.1.tgz",
+      "integrity": "sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==",
       "dev": true
     },
     "prettier-plugin-organize-imports": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-2.3.4.tgz",
-      "integrity": "sha512-R8o23sf5iVL/U71h9SFUdhdOEPsi3nm42FD/oDYIZ2PQa4TNWWuWecxln6jlIQzpZTDMUeO1NicJP6lLn2TtRw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-3.2.1.tgz",
+      "integrity": "sha512-bty7C2Ecard5EOXirtzeCAqj4FU4epeuWrQt/Z+sh8UVEpBlBZ3m3KNPz2kFu7KgRTQx/C9o4/TdquPD1jOqjQ==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-deprecation": "^1.2.1",
     "eslint-plugin-unused-imports": "^1.1.1",
-    "prettier": "^2.3.2",
-    "prettier-plugin-organize-imports": "^2.3.4",
+    "prettier": "^2.8.1",
+    "prettier-plugin-organize-imports": "^3.2.1",
     "typescript": "^4.3.4"
   }
 }

--- a/packages/hooks/CHANGELOG.md
+++ b/packages/hooks/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 #### Fixed
 
+- Fix imports order by updating `prettier` and `prettier-plugin-organize-imports` [#114](https://github.com/liteflow-labs/liteflow-js/pull/114)
+
 #### Security
 
 ## [v1.0.0-beta.10](https://github.com/liteflow-labs/libraries/releases/tag/v1.0.0-beta.10) - 2022-12-23

--- a/packages/hooks/src/context.tsx
+++ b/packages/hooks/src/context.tsx
@@ -1,5 +1,5 @@
-import decode, { JwtPayload } from 'jwt-decode'
 import { gql, GraphQLClient } from 'graphql-request'
+import decode, { JwtPayload } from 'jwt-decode'
 import React, {
   createContext,
   PropsWithChildren,

--- a/packages/hooks/src/useAddFund.ts
+++ b/packages/hooks/src/useAddFund.ts
@@ -3,8 +3,8 @@ import { gql } from 'graphql-request'
 import { useCallback, useContext, useState } from 'react'
 import invariant from 'ts-invariant'
 import { LiteflowContext } from './context'
-import useConfig from './useConfig'
 import { ErrorMessages } from './errorMessages'
+import useConfig from './useConfig'
 
 gql`
   mutation CreateWyrePayment($address: Address!) {

--- a/packages/hooks/src/useInvitation.ts
+++ b/packages/hooks/src/useInvitation.ts
@@ -3,8 +3,8 @@ import { gql } from 'graphql-request'
 import { useCallback, useContext, useState } from 'react'
 import invariant from 'ts-invariant'
 import { LiteflowContext } from './context'
-import useConfig from './useConfig'
 import { ErrorMessages } from './errorMessages'
+import useConfig from './useConfig'
 
 gql`
   mutation CreateInvitation {

--- a/packages/hooks/src/useIsLoggedIn.ts
+++ b/packages/hooks/src/useIsLoggedIn.ts
@@ -1,4 +1,4 @@
-import { useMemo, useContext } from 'react'
+import { useContext, useMemo } from 'react'
 import { LiteflowContext } from './context'
 import { isSameAddress } from './utils/address'
 


### PR DESCRIPTION
### Project organization

- Closes https://github.com/liteflow-labs/liteflow-js/issues/113

### Description

Fix import order by updating version of prettier and prettier-plugin-organize-imports.

### How to test

- Change the import orders in a file, save, the import should be automatically re-ordered.

### Checklist

- [x] Update related changelogs <!-- Check [root's CHANGELOG.md](/CHANGELOG.md) to access the right changelogs -->
