### PR TITLE
Use new mutations createCurrencyApprovalTransaction and createCollectionApprovalTransaction

### DIFF
--- a/packages/hooks/CHANGELOG.md
+++ b/packages/hooks/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 #### Changed
 
+- Use mutations `createCurrencyApprovalTransaction` and `createCollectionApprovalTransaction` instead of `token.approval` and `currency.approval` in `useCreateOffer` and `useAcceptOffer` hooks [#117](https://github.com/liteflow-labs/liteflow-js/pull/117)
+
 #### Deprecated
 
 #### Removed

--- a/packages/hooks/src/useAcceptOffer.ts
+++ b/packages/hooks/src/useAcceptOffer.ts
@@ -10,7 +10,7 @@ import useCheckOwnership from './useCheckOwnership'
 import { convertTx } from './utils/transaction'
 
 gql`
-  query OfferWithApproval($offerId: UUID!, $taker: Address!) {
+  query FetchOffer($offerId: UUID!, $taker: Address!) {
     offer(id: $offerId) {
       type
       makerAddress
@@ -82,7 +82,7 @@ export default function useAcceptOffer(signer: Signer | undefined): [
 
       try {
         // fetch approval from api
-        const { offer } = await sdk.OfferWithApproval({
+        const { offer } = await sdk.FetchOffer({
           offerId: id,
           taker: account.toLowerCase(),
         })

--- a/packages/hooks/src/useAcceptOffer.ts
+++ b/packages/hooks/src/useAcceptOffer.ts
@@ -13,7 +13,7 @@ gql`
   query OfferWithApprovalAndFill(
     $offerId: UUID!
     $taker: Address!
-    $quantity: Uint256! # $amount: Uint256!
+    $quantity: Uint256!
   ) {
     offer(id: $offerId) {
       type

--- a/packages/hooks/src/useAcceptOffer.ts
+++ b/packages/hooks/src/useAcceptOffer.ts
@@ -130,7 +130,10 @@ export default function useAcceptOffer(signer: Signer | undefined): [
           })
         } else {
           // accepting an offer of type buy, approval is on the asset
-          await approveCollection(offer.asset)
+          await approveCollection({
+            chainId: offer.asset.chainId,
+            collectionAddress: offer.asset.collectionAddress,
+          })
         }
 
         // determine the asset id to check ownership from

--- a/packages/hooks/src/useAcceptOffer.ts
+++ b/packages/hooks/src/useAcceptOffer.ts
@@ -13,7 +13,7 @@ import useCheckOwnership from './useCheckOwnership'
 import { convertTx } from './utils/transaction'
 
 gql`
-  query FetchOffer($offerId: UUID!, $taker: Address!) {
+  query FetchOffer($offerId: UUID!) {
     offer(id: $offerId) {
       type
       makerAddress
@@ -118,7 +118,6 @@ export default function useAcceptOffer(signer: Signer | undefined): [
         // fetch approval from api
         const { offer } = await sdk.FetchOffer({
           offerId: id,
-          taker: account.toLowerCase(),
         })
         invariant(offer, ErrorMessages.OFFER_NOT_FOUND)
 

--- a/packages/hooks/src/useAcceptOffer.ts
+++ b/packages/hooks/src/useAcceptOffer.ts
@@ -76,10 +76,20 @@ export default function useAcceptOffer(signer: Signer | undefined): [
     AcceptOfferStep.INITIAL,
   )
   const [transactionHash, setTransactionHash] = useState<string>()
-  const [approveCurrency, { activeStep: approveCurrencyActiveStep }] =
-    useApproveCurrency(signer)
-  const [approveCollection, { activeStep: approveCollectionActiveStep }] =
-    useApproveCollection(signer)
+  const [
+    approveCurrency,
+    {
+      activeStep: approveCurrencyActiveStep,
+      transactionHash: approveCurrencyTransactionHash,
+    },
+  ] = useApproveCurrency(signer)
+  const [
+    approveCollection,
+    {
+      activeStep: approveCollectionActiveStep,
+      transactionHash: approveCollectionTransactionHash,
+    },
+  ] = useApproveCollection(signer)
 
   // sync approve currency active step
   useEffect(() => {
@@ -108,6 +118,16 @@ export default function useAcceptOffer(signer: Signer | undefined): [
       }
     }
   }, [approveCollectionActiveStep])
+
+  // sync approve currency transaction hash
+  useEffect(() => {
+    setTransactionHash(approveCurrencyTransactionHash)
+  }, [approveCurrencyTransactionHash])
+
+  // sync approve collection transaction hash
+  useEffect(() => {
+    setTransactionHash(approveCollectionTransactionHash)
+  }, [approveCollectionTransactionHash])
 
   const acceptOffer: acceptOfferFn = useCallback(
     async ({ id, unitPrice }, quantity) => {

--- a/packages/hooks/src/useApproveCollection.ts
+++ b/packages/hooks/src/useApproveCollection.ts
@@ -1,0 +1,84 @@
+import { Signer } from '@ethersproject/abstract-signer'
+import { gql } from 'graphql-request'
+import { useCallback, useContext, useState } from 'react'
+import invariant from 'ts-invariant'
+import { LiteflowContext } from './context'
+import { ErrorMessages } from './errorMessages'
+import { convertTx } from './utils/transaction'
+
+gql`
+  mutation CreateCollectionApprovalTransaction(
+    $accountAddress: Address!
+    $chainId: Int!
+    $collectionAddress: String!
+  ) {
+    createCollectionApprovalTransaction(
+      accountAddress: $accountAddress
+      chainId: $chainId
+      collectionAddress: $collectionAddress
+    ) {
+      transaction {
+        ...Transaction
+      }
+    }
+  }
+`
+
+export enum ApproveCollectionStep {
+  INITIAL,
+  SIGNATURE,
+  PENDING,
+}
+
+export default function useApproveCollection(signer: Signer | undefined): [
+  (data: { chainId: number; collectionAddress: string }) => Promise<void>,
+  {
+    activeStep: ApproveCollectionStep
+    transactionHash: string | undefined
+  },
+] {
+  const { sdk } = useContext(LiteflowContext)
+  const [transactionHash, setTransactionHash] = useState<string>()
+  const [activeStep, setActiveProcess] = useState<ApproveCollectionStep>(
+    ApproveCollectionStep.INITIAL,
+  )
+
+  const approveCollection = useCallback(
+    async ({
+      chainId,
+      collectionAddress,
+    }: {
+      chainId: number
+      collectionAddress: string
+    }): Promise<void> => {
+      invariant(signer, ErrorMessages.SIGNER_FALSY)
+      try {
+        setActiveProcess(ApproveCollectionStep.SIGNATURE)
+        const account = await signer.getAddress()
+        const { createCollectionApprovalTransaction } =
+          await sdk.CreateCollectionApprovalTransaction({
+            accountAddress: account.toLowerCase(),
+            chainId: chainId,
+            collectionAddress: collectionAddress.toLowerCase(),
+          })
+        const approval = createCollectionApprovalTransaction.transaction
+        if (!approval) return
+
+        // must authorize operator by executing a transaction
+        console.info(`must authorized operator first`)
+        const tx = await signer.sendTransaction(convertTx(approval))
+        setActiveProcess(ApproveCollectionStep.PENDING)
+        setTransactionHash(tx.hash)
+        console.info(`waiting for transaction with hash ${tx.hash}...`)
+        await tx.wait()
+        console.info(`transaction validated`)
+      } finally {
+        setTransactionHash(undefined)
+        setActiveProcess(ApproveCollectionStep.INITIAL)
+      }
+    },
+    [sdk, signer],
+  )
+
+  return [approveCollection, { activeStep, transactionHash }]
+}

--- a/packages/hooks/src/useApproveCurrency.ts
+++ b/packages/hooks/src/useApproveCurrency.ts
@@ -1,0 +1,85 @@
+import { Signer } from '@ethersproject/abstract-signer'
+import { BigNumber } from '@ethersproject/bignumber'
+import { gql } from 'graphql-request'
+import { useCallback, useContext, useState } from 'react'
+import invariant from 'ts-invariant'
+import { LiteflowContext } from './context'
+import { ErrorMessages } from './errorMessages'
+import { convertTx } from './utils/transaction'
+
+gql`
+  mutation CreateCurrencyApprovalTransaction(
+    $accountAddress: Address!
+    $amount: Uint256!
+    $currencyId: String!
+  ) {
+    createCurrencyApprovalTransaction(
+      accountAddress: $accountAddress
+      amount: $amount
+      currencyId: $currencyId
+    ) {
+      transaction {
+        ...Transaction
+      }
+    }
+  }
+`
+
+export enum ApproveCurrencyStep {
+  INITIAL,
+  SIGNATURE,
+  PENDING,
+}
+
+export default function useApproveCurrency(signer: Signer | undefined): [
+  (data: { amount: BigNumber; currencyId: string }) => Promise<void>,
+  {
+    activeStep: ApproveCurrencyStep
+    transactionHash: string | undefined
+  },
+] {
+  const { sdk } = useContext(LiteflowContext)
+  const [transactionHash, setTransactionHash] = useState<string>()
+  const [activeStep, setActiveProcess] = useState<ApproveCurrencyStep>(
+    ApproveCurrencyStep.INITIAL,
+  )
+
+  const approveCurrency = useCallback(
+    async ({
+      amount,
+      currencyId,
+    }: {
+      amount: BigNumber
+      currencyId: string
+    }): Promise<void> => {
+      invariant(signer, ErrorMessages.SIGNER_FALSY)
+      try {
+        setActiveProcess(ApproveCurrencyStep.SIGNATURE)
+        const account = await signer.getAddress()
+        const { createCurrencyApprovalTransaction } =
+          await sdk.CreateCurrencyApprovalTransaction({
+            accountAddress: account.toLowerCase(),
+            currencyId: currencyId,
+            amount: amount.toString(),
+          })
+        const approval = createCurrencyApprovalTransaction.transaction
+        if (!approval) return
+
+        // must authorize operator by executing a transaction
+        console.info(`must authorized operator first`)
+        const tx = await signer.sendTransaction(convertTx(approval))
+        setActiveProcess(ApproveCurrencyStep.PENDING)
+        setTransactionHash(tx.hash)
+        console.info(`waiting for transaction with hash ${tx.hash}...`)
+        await tx.wait()
+        console.info(`transaction validated`)
+      } finally {
+        setTransactionHash(undefined)
+        setActiveProcess(ApproveCurrencyStep.INITIAL)
+      }
+    },
+    [sdk, signer],
+  )
+
+  return [approveCurrency, { activeStep, transactionHash }]
+}

--- a/packages/hooks/src/useCreateOffer.ts
+++ b/packages/hooks/src/useCreateOffer.ts
@@ -150,7 +150,10 @@ export default function useCreateOffer(
 
         if (type === 'SALE') {
           // creating a new offer of type sale, approval is on the asset
-          await approveCollection(asset)
+          await approveCollection({
+            chainId: asset.chainId,
+            collectionAddress: asset.collectionAddress,
+          })
         } else {
           // creating a new offer of type buy, approval is on the currency
           await approveCurrency({


### PR DESCRIPTION
### Project organization

- Related https://github.com/liteflow-labs/backend/issues/2402
- Dependant on https://github.com/liteflow-labs/backend/pull/2403

### Description

Use mutations `createCurrencyApprovalTransaction` and `createCollectionApprovalTransaction` in `useCreateOffer` and `useAcceptOffer`.

### How to test

<!-- A concise explanation how to test this PR with links -->

### Checklist

- [x] Update related changelogs <!-- Check [root's CHANGELOG.md](/CHANGELOG.md) to access the right changelogs -->
