### PR TITLE
Use new mutation createOfferFillTransaction

### DIFF
--- a/packages/hooks/CHANGELOG.md
+++ b/packages/hooks/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 #### Changed
 
+- Use use `createOfferFillTransaction` instead of deprecated `offer.fill` in `useAcceptOffer` hook [#118](https://github.com/liteflow-labs/liteflow-js/pull/118)
+
 #### Deprecated
 
 #### Removed

--- a/packages/hooks/src/useAcceptOffer.ts
+++ b/packages/hooks/src/useAcceptOffer.ts
@@ -10,7 +10,7 @@ import useCheckOwnership from './useCheckOwnership'
 import { convertTx } from './utils/transaction'
 
 gql`
-  query OfferWithApprovalAndFill(
+  query OfferWithApproval(
     $offerId: UUID!
     $taker: Address!
     $amount: Uint256!
@@ -101,7 +101,7 @@ export default function useAcceptOffer(signer: Signer | undefined): [
 
       try {
         // fetch approval from api
-        const { offer } = await sdk.OfferWithApprovalAndFill({
+        const { offer } = await sdk.OfferWithApproval({
           offerId: id,
           taker: account.toLowerCase(),
           amount: BigNumber.from(unitPrice).mul(quantity).toString(),


### PR DESCRIPTION
### Project organization

- Related https://github.com/liteflow-labs/backend/issues/2404
- Dependant on https://github.com/liteflow-labs/backend/pull/2405

### Description

- use `createOfferFillTransaction` instead of `offer.fill` in `useAcceptOffer` hook

### How to test

<!-- A concise explanation how to test this PR with links -->

### Checklist

- [x] Update related changelogs <!-- Check [root's CHANGELOG.md](/CHANGELOG.md) to access the right changelogs -->
