### PR TITLE
Update `useConfig` to return a function instead of the promise

### DIFF
--- a/packages/hooks/CHANGELOG.md
+++ b/packages/hooks/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 #### Breaking Changes
 
+- Update `useConfig` return parameter from `Promise<Config>` to `() => Promise<Config>` [#]()
+  - Make sure to update your codebase with `const getConfig = useConfig(); ... await getConfig()`
+
 #### Added
 
 #### Changed
@@ -14,6 +17,7 @@
 
 #### Fixed
 
+- Fix issue on initial render on SSR due to pending promise [#]()
 - Fix imports order by updating `prettier` and `prettier-plugin-organize-imports` [#114](https://github.com/liteflow-labs/liteflow-js/pull/114)
 
 #### Security

--- a/packages/hooks/CHANGELOG.md
+++ b/packages/hooks/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 #### Breaking Changes
 
-- Update `useConfig` return parameter from `Promise<Config>` to `() => Promise<Config>` [#]()
-  - Make sure to update your codebase with `const getConfig = useConfig(); ... await getConfig()`
+- Update `useConfig` return parameter from `Promise<Config>` to `{ data?: Config, error?: Error }` [#120](https://github.com/liteflow-labs/liteflow-js/pull/120)
+  - Make sure to update your codebase with `const { data } = useConfig();`
 
 #### Added
 
@@ -17,7 +17,7 @@
 
 #### Fixed
 
-- Fix issue on initial render on SSR due to pending promise [#]()
+- Fix issue on initial render on SSR due to pending promise [#120](https://github.com/liteflow-labs/liteflow-js/pull/120)
 - Fix imports order by updating `prettier` and `prettier-plugin-organize-imports` [#114](https://github.com/liteflow-labs/liteflow-js/pull/114)
 
 #### Security

--- a/packages/hooks/CHANGELOG.md
+++ b/packages/hooks/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 #### Removed
 
+- `config` has been removed from the `LiteflowContext` [#120](https://github.com/liteflow-labs/liteflow-js/pull/120)
+
 #### Fixed
 
 - Fix issue on initial render on SSR due to pending promise [#120](https://github.com/liteflow-labs/liteflow-js/pull/120)

--- a/packages/hooks/src/context.tsx
+++ b/packages/hooks/src/context.tsx
@@ -28,7 +28,7 @@ export type LiteflowContext = {
   resetAuthenticationToken: () => void
   currentAddress: string | null
   sdk: Sdk
-  config: Promise<Config>
+  config: () => Promise<Config>
 }
 
 export type LiteflowProviderProps = {
@@ -44,7 +44,7 @@ export const LiteflowContext = createContext<LiteflowContext>({
   },
   currentAddress: null,
   sdk: {} as Sdk,
-  config: {} as Promise<Config>,
+  config: () => ({} as Promise<Config>),
 })
 
 export function LiteflowProvider({
@@ -54,10 +54,13 @@ export function LiteflowProvider({
   const [authenticationToken, setAuthenticationToken] = useState<string>()
   const client = useMemo(() => new GraphQLClient(endpoint), [endpoint])
   const sdk = useMemo(() => getSdk(client), [client])
-  const config = useMemo(
-    () => sdk.GetConfig().then(({ config }) => config),
-    [sdk],
-  )
+  const [configPromise, setConfigPromise] = useState<Promise<Config>>()
+  const config = useCallback(() => {
+    if (configPromise) return configPromise
+    const promise = sdk.GetConfig().then(({ config }) => config)
+    setConfigPromise(promise)
+    return promise
+  }, [sdk, configPromise, setConfigPromise])
   const currentAddress = useMemo(() => {
     if (!authenticationToken) return null
     const res = decode<JwtPayload & { address: string }>(authenticationToken)

--- a/packages/hooks/src/context.tsx
+++ b/packages/hooks/src/context.tsx
@@ -8,7 +8,7 @@ import React, {
   useMemo,
   useState,
 } from 'react'
-import type { Config, Sdk } from './graphql'
+import type { Sdk } from './graphql'
 import { getSdk } from './graphql'
 
 gql`
@@ -28,7 +28,6 @@ export type LiteflowContext = {
   resetAuthenticationToken: () => void
   currentAddress: string | null
   sdk: Sdk
-  config: () => Promise<Config>
 }
 
 export type LiteflowProviderProps = {
@@ -44,7 +43,6 @@ export const LiteflowContext = createContext<LiteflowContext>({
   },
   currentAddress: null,
   sdk: {} as Sdk,
-  config: () => ({} as Promise<Config>),
 })
 
 export function LiteflowProvider({
@@ -54,13 +52,6 @@ export function LiteflowProvider({
   const [authenticationToken, setAuthenticationToken] = useState<string>()
   const client = useMemo(() => new GraphQLClient(endpoint), [endpoint])
   const sdk = useMemo(() => getSdk(client), [client])
-  const [configPromise, setConfigPromise] = useState<Promise<Config>>()
-  const config = useCallback(() => {
-    if (configPromise) return configPromise
-    const promise = sdk.GetConfig().then(({ config }) => config)
-    setConfigPromise(promise)
-    return promise
-  }, [sdk, configPromise, setConfigPromise])
   const currentAddress = useMemo(() => {
     if (!authenticationToken) return null
     const res = decode<JwtPayload & { address: string }>(authenticationToken)
@@ -88,7 +79,6 @@ export function LiteflowProvider({
         setAuthenticationToken,
         currentAddress,
         sdk,
-        config,
       }}
     >
       {children}

--- a/packages/hooks/src/useAddFund.ts
+++ b/packages/hooks/src/useAddFund.ts
@@ -20,10 +20,11 @@ export default function useAddFund(
 ): [() => Promise<void>, { loading: boolean }] {
   const { sdk } = useContext(LiteflowContext)
   const [loading, setLoading] = useState(false)
-  const config = useConfig()
+  const getConfig = useConfig()
 
   const addFunds = useCallback(async () => {
-    invariant((await config).hasTopUp, ErrorMessages.FEATURE_DISABLED_TOP_UP)
+    const { hasTopUp } = await getConfig()
+    invariant(hasTopUp, ErrorMessages.FEATURE_DISABLED_TOP_UP)
     invariant(signer, ErrorMessages.SIGNER_FALSY)
     try {
       setLoading(true)
@@ -36,6 +37,6 @@ export default function useAddFund(
     } finally {
       setLoading(false)
     }
-  }, [sdk, signer, config])
+  }, [sdk, signer, getConfig])
   return [addFunds, { loading }]
 }

--- a/packages/hooks/src/useAddFund.ts
+++ b/packages/hooks/src/useAddFund.ts
@@ -4,7 +4,6 @@ import { useCallback, useContext, useState } from 'react'
 import invariant from 'ts-invariant'
 import { LiteflowContext } from './context'
 import { ErrorMessages } from './errorMessages'
-import useConfig from './useConfig'
 
 gql`
   mutation CreateWyrePayment($address: Address!) {
@@ -20,10 +19,11 @@ export default function useAddFund(
 ): [() => Promise<void>, { loading: boolean }] {
   const { sdk } = useContext(LiteflowContext)
   const [loading, setLoading] = useState(false)
-  const getConfig = useConfig()
 
   const addFunds = useCallback(async () => {
-    const { hasTopUp } = await getConfig()
+    const {
+      config: { hasTopUp },
+    } = await sdk.GetConfig()
     invariant(hasTopUp, ErrorMessages.FEATURE_DISABLED_TOP_UP)
     invariant(signer, ErrorMessages.SIGNER_FALSY)
     try {
@@ -37,6 +37,6 @@ export default function useAddFund(
     } finally {
       setLoading(false)
     }
-  }, [sdk, signer, getConfig])
+  }, [sdk, signer])
   return [addFunds, { loading }]
 }

--- a/packages/hooks/src/useConfig.ts
+++ b/packages/hooks/src/useConfig.ts
@@ -24,7 +24,11 @@ export default function useConfig(): ConfigResult {
       .then(({ config }) => setConfig(config))
       .catch(setError)
       .finally(() => setLoading(false))
-    return () => setConfig(undefined)
+    return () => {
+      setError(undefined)
+      setLoading(false)
+      setConfig(undefined)
+    }
   }, [setConfig, setError, sdk])
 
   return {

--- a/packages/hooks/src/useConfig.ts
+++ b/packages/hooks/src/useConfig.ts
@@ -1,8 +1,28 @@
-import { useContext } from 'react'
+import { useContext, useEffect, useState } from 'react'
 import { LiteflowContext } from './context'
 import { Config } from './graphql'
 
-export default function useConfig(): () => Promise<Config> {
-  const { config } = useContext(LiteflowContext)
-  return config
+// This type can be reused for any other read-only hook
+type Result<T = any> = {
+  data?: T
+  error?: Error
+}
+
+export default function useConfig(): Result<Config> {
+  const { sdk } = useContext(LiteflowContext)
+  const [config, setConfig] = useState<Config>()
+  const [error, setError] = useState<Error>()
+
+  useEffect(() => {
+    sdk
+      .GetConfig()
+      .then(({ config }) => config)
+      .catch(setError)
+    return () => setConfig(undefined)
+  }, [setConfig, setError, sdk])
+
+  return {
+    data: config,
+    error,
+  }
 }

--- a/packages/hooks/src/useConfig.ts
+++ b/packages/hooks/src/useConfig.ts
@@ -6,23 +6,30 @@ import { Config } from './graphql'
 type Result<T = any> = {
   data?: T
   error?: Error
+  loading: boolean
 }
 
-export default function useConfig(): Result<Config> {
+export type ConfigResult = Result<Config>
+
+export default function useConfig(): ConfigResult {
   const { sdk } = useContext(LiteflowContext)
   const [config, setConfig] = useState<Config>()
   const [error, setError] = useState<Error>()
+  const [loading, setLoading] = useState<boolean>(false)
 
   useEffect(() => {
+    setLoading(true)
     sdk
       .GetConfig()
-      .then(({ config }) => config)
+      .then(({ config }) => setConfig(config))
       .catch(setError)
+      .finally(() => setLoading(false))
     return () => setConfig(undefined)
   }, [setConfig, setError, sdk])
 
   return {
     data: config,
     error,
+    loading,
   }
 }

--- a/packages/hooks/src/useConfig.ts
+++ b/packages/hooks/src/useConfig.ts
@@ -2,7 +2,7 @@ import { useContext } from 'react'
 import { LiteflowContext } from './context'
 import { Config } from './graphql'
 
-export default function useConfig(): Promise<Config> {
+export default function useConfig(): () => Promise<Config> {
   const { config } = useContext(LiteflowContext)
   return config
 }

--- a/packages/hooks/src/useCreateNFT.ts
+++ b/packages/hooks/src/useCreateNFT.ts
@@ -6,7 +6,6 @@ import { LiteflowContext } from './context'
 import { ErrorMessages } from './errorMessages'
 import { LazyMintedAssetSignatureInput } from './graphql'
 import useCheckOwnership from './useCheckOwnership'
-import useConfig from './useConfig'
 import useIPFSUploader from './useIPFSUploader'
 import { convertTx } from './utils/transaction'
 
@@ -110,7 +109,6 @@ export default function useCreateNFT(
   },
 ] {
   const { sdk } = useContext(LiteflowContext)
-  const getConfig = useConfig()
   const [transactionHash, setTransactionHash] = useState<string>()
   const [activeStep, setActiveProcess] = useState<CreateNftStep>(
     CreateNftStep.INITIAL,
@@ -181,7 +179,9 @@ export default function useCreateNFT(
       royalties,
       traits,
     }) => {
-      const { hasLazyMint, hasUnlockableContent } = await getConfig()
+      const {
+        config: { hasLazyMint, hasUnlockableContent },
+      } = await sdk.GetConfig()
       invariant(
         !isPrivate || (isPrivate && hasUnlockableContent),
         ErrorMessages.FEATURE_DISABLED_UNLOCKABLE_CONTENT,
@@ -290,7 +290,7 @@ export default function useCreateNFT(
         setTransactionHash(undefined)
       }
     },
-    [sdk, signer, pollOwnership, uploadMedia, getConfig],
+    [sdk, signer, pollOwnership, uploadMedia],
   )
 
   return [createNft, { activeStep, transactionHash }]

--- a/packages/hooks/src/useCreateNFT.ts
+++ b/packages/hooks/src/useCreateNFT.ts
@@ -110,7 +110,7 @@ export default function useCreateNFT(
   },
 ] {
   const { sdk } = useContext(LiteflowContext)
-  const config = useConfig()
+  const getConfig = useConfig()
   const [transactionHash, setTransactionHash] = useState<string>()
   const [activeStep, setActiveProcess] = useState<CreateNftStep>(
     CreateNftStep.INITIAL,
@@ -181,8 +181,9 @@ export default function useCreateNFT(
       royalties,
       traits,
     }) => {
+      const { hasLazyMint, hasUnlockableContent } = await getConfig()
       invariant(
-        !isPrivate || (isPrivate && (await config).hasUnlockableContent),
+        !isPrivate || (isPrivate && hasUnlockableContent),
         ErrorMessages.FEATURE_DISABLED_UNLOCKABLE_CONTENT,
       )
       invariant(signer, ErrorMessages.SIGNER_FALSY)
@@ -214,7 +215,7 @@ export default function useCreateNFT(
         }
 
         // lazy minting
-        if ((await config).hasLazyMint) {
+        if (hasLazyMint) {
           const { createLazyMintedAssetSignature } =
             await sdk.CreateLazyMintedAssetSignature({
               chainId: chainId,
@@ -289,7 +290,7 @@ export default function useCreateNFT(
         setTransactionHash(undefined)
       }
     },
-    [sdk, signer, pollOwnership, uploadMedia, config],
+    [sdk, signer, pollOwnership, uploadMedia, getConfig],
   )
 
   return [createNft, { activeStep, transactionHash }]

--- a/packages/hooks/src/useInvitation.ts
+++ b/packages/hooks/src/useInvitation.ts
@@ -4,7 +4,6 @@ import { useCallback, useContext, useState } from 'react'
 import invariant from 'ts-invariant'
 import { LiteflowContext } from './context'
 import { ErrorMessages } from './errorMessages'
-import useConfig from './useConfig'
 
 gql`
   mutation CreateInvitation {
@@ -41,11 +40,12 @@ export default function useInvitation(signer: Signer | undefined): {
   creating: boolean
 } {
   const { sdk } = useContext(LiteflowContext)
-  const getConfig = useConfig()
   const [accepting, setAccepting] = useState(false)
   const [creating, setCreating] = useState(false)
   const create = useCallback(async () => {
-    const { hasReferralSystem } = await getConfig()
+    const {
+      config: { hasReferralSystem },
+    } = await sdk.GetConfig()
     invariant(hasReferralSystem, ErrorMessages.FEATURE_DISABLED_REFERRAL)
     invariant(signer, ErrorMessages.SIGNER_FALSY)
     try {
@@ -65,11 +65,13 @@ export default function useInvitation(signer: Signer | undefined): {
     } finally {
       setCreating(false)
     }
-  }, [sdk, signer, getConfig])
+  }, [sdk, signer])
 
   const accept = useCallback(
     async (invitationId: string) => {
-      const { hasReferralSystem } = await getConfig()
+      const {
+        config: { hasReferralSystem },
+      } = await sdk.GetConfig()
       invariant(hasReferralSystem, ErrorMessages.FEATURE_DISABLED_REFERRAL)
       try {
         setAccepting(true)
@@ -85,7 +87,7 @@ export default function useInvitation(signer: Signer | undefined): {
         setAccepting(false)
       }
     },
-    [sdk, getConfig],
+    [sdk],
   )
 
   return { create, accept, accepting, creating }

--- a/packages/hooks/src/useInvitation.ts
+++ b/packages/hooks/src/useInvitation.ts
@@ -41,14 +41,12 @@ export default function useInvitation(signer: Signer | undefined): {
   creating: boolean
 } {
   const { sdk } = useContext(LiteflowContext)
-  const config = useConfig()
+  const getConfig = useConfig()
   const [accepting, setAccepting] = useState(false)
   const [creating, setCreating] = useState(false)
   const create = useCallback(async () => {
-    invariant(
-      (await config).hasReferralSystem,
-      ErrorMessages.FEATURE_DISABLED_REFERRAL,
-    )
+    const { hasReferralSystem } = await getConfig()
+    invariant(hasReferralSystem, ErrorMessages.FEATURE_DISABLED_REFERRAL)
     invariant(signer, ErrorMessages.SIGNER_FALSY)
     try {
       setCreating(true)
@@ -67,14 +65,12 @@ export default function useInvitation(signer: Signer | undefined): {
     } finally {
       setCreating(false)
     }
-  }, [sdk, signer, config])
+  }, [sdk, signer, getConfig])
 
   const accept = useCallback(
     async (invitationId: string) => {
-      invariant(
-        (await config).hasReferralSystem,
-        ErrorMessages.FEATURE_DISABLED_REFERRAL,
-      )
+      const { hasReferralSystem } = await getConfig()
+      invariant(hasReferralSystem, ErrorMessages.FEATURE_DISABLED_REFERRAL)
       try {
         setAccepting(true)
         const { acceptInvitation } = await sdk.AcceptInvitation({
@@ -89,7 +85,7 @@ export default function useInvitation(signer: Signer | undefined): {
         setAccepting(false)
       }
     },
-    [sdk, config],
+    [sdk, getConfig],
   )
 
   return { create, accept, accepting, creating }


### PR DESCRIPTION
Trello card: https://trello.com/c/UfqGqE5w/507-fix-cold-start-of-ssr-functions

Fix an issue with server side rendering (with cloud function) because of an unterminated promise.
This is because of the config promise that does not has time to be resolved before the function finishes.

Instead of now returning directly the promise to the config, the `useConfig` returns a function returning a payload containing the data.

This is a breaking change and requires all the calls of `useConfig` to be updated as follow

## Before
```ts
const config = useConfig()
...
(await config).xxx
```

## After
```ts
const { data: config } = useConfig()
...
config?.xxx
```