### PR TITLE
Invalid jwt with expired date

### DIFF
--- a/packages/hooks/CHANGELOG.md
+++ b/packages/hooks/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 #### Fixed
 
+- Invalid jwt with expired date [#123](https://github.com/liteflow-labs/liteflow-js/pull/123)
+
 #### Security
 
 ## [v1.0.0-beta.11](https://github.com/liteflow-labs/libraries/releases/tag/v1.0.0-beta.11) - 2023-01-09

--- a/packages/hooks/src/context.tsx
+++ b/packages/hooks/src/context.tsx
@@ -55,6 +55,7 @@ export function LiteflowProvider({
   const currentAddress = useMemo(() => {
     if (!authenticationToken) return null
     const res = decode<JwtPayload & { address: string }>(authenticationToken)
+    if (res.exp && res.exp < Math.ceil(Date.now() / 1000)) return null
     return res.address
   }, [authenticationToken])
 


### PR DESCRIPTION
### Description

JWTs with expired date expired were still considered as valid. Now these jwt will be discarded

### How to test

Shorten the exp date for the jwt on the backend to a couple of seconds.
Go to a page that reads the `useIsLoggedIn` (which reads the connected address). 
For example the profile page of the user, the edit button should appear
Wait for the expiration of the jwt. 
Without this PR, the button edit is still active
With this PR the button is not active anymore as the jwt is expired

### Checklist

- [x] Update related changelogs <!-- Check [root's CHANGELOG.md](/CHANGELOG.md) to access the right changelogs -->
