### PR TITLE
Ensure lazyminted assets poll for ownership

### DIFF
--- a/packages/hooks/CHANGELOG.md
+++ b/packages/hooks/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 #### Fixed
 
+- Fix issue with pending ownership on lazyminted assets [#137](https://github.com/liteflow-labs/liteflow-js/pull/137)
+
 #### Security
 
 ## [v1.0.0-beta.12](https://github.com/liteflow-labs/libraries/releases/tag/v1.0.0-beta.12) - 2023-02-07

--- a/packages/hooks/src/useCreateNFT.ts
+++ b/packages/hooks/src/useCreateNFT.ts
@@ -250,6 +250,15 @@ export default function useCreateNFT(
             createLazyMintedAsset?.asset,
             ErrorMessages.ASSET_LAZY_MINT_CREATION_FAILED,
           )
+          setActiveProcess(CreateNftStep.OWNERSHIP)
+          // poll the api until the ownership is updated
+          console.info('polling api to check ownership...')
+          await pollOwnership({
+            assetId: createLazyMintedAsset.asset.id,
+            ownerAddress: account.toLowerCase(),
+            initialQuantity: '0',
+          })
+          console.info('polling done')
           return createLazyMintedAsset.asset.id
         }
 


### PR DESCRIPTION
### Description

Ensure the library is waiting for the ownership to be checked even for lazyminted assets as these could also take time to be verified

### How to test

Mind an NFT with lazyminted assets and check that the asset has an ownership just after calling the `useCreateNFT`. This was not always the case before

