### PR TITLE
Fix too permissive types for config

### DIFF
--- a/packages/hooks/CHANGELOG.md
+++ b/packages/hooks/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 #### Fixed
 
+- Fix future issues with config type and too permissive type [#138](https://github.com/liteflow-labs/liteflow-js/pull/138)
+
 #### Security
 
 ## [v1.0.0-beta.12](https://github.com/liteflow-labs/libraries/releases/tag/v1.0.0-beta.12) - 2023-02-07

--- a/packages/hooks/src/useConfig.ts
+++ b/packages/hooks/src/useConfig.ts
@@ -1,6 +1,6 @@
 import { useContext, useEffect, useState } from 'react'
 import { LiteflowContext } from './context'
-import { Config } from './graphql'
+import { GetConfigQuery } from './graphql'
 
 // This type can be reused for any other read-only hook
 type Result<T = any> = {
@@ -9,6 +9,7 @@ type Result<T = any> = {
   loading: boolean
 }
 
+type Config = Omit<GetConfigQuery['config'], '__typename'>
 export type ConfigResult = Result<Config>
 
 export default function useConfig(): ConfigResult {


### PR DESCRIPTION
### Description

With the new updates on the API, the current config type will fail because of additional props that are not requested. To fix this, the type is defined by what is returned from the query executed.

### How to test

Build with the latest API schema, the build should fail then build with this fix and everything should build properly
