### PR TITLE
Fix page titles in the doc

### DIFF
--- a/docs/pages/sdk/core/account.md
+++ b/docs/pages/sdk/core/account.md
@@ -1,3 +1,7 @@
+---
+title: 'Account'
+---
+
 # Account
 
 The `Account` module provides methods to update and verify an account.

--- a/docs/pages/sdk/core/asset.md
+++ b/docs/pages/sdk/core/asset.md
@@ -1,3 +1,7 @@
+---
+title: 'Asset'
+---
+
 # Asset
 
 The `Asset` module provides methods to mint assets either directly on-chain or off-chain (lazymint). Lazyminted assets are minted on-chain when they are purchased.

--- a/docs/pages/sdk/core/exchange.md
+++ b/docs/pages/sdk/core/exchange.md
@@ -1,3 +1,7 @@
+---
+title: 'Exchange'
+---
+
 # Exchange
 
 The `Exchange` module provides a set of methods to interact with the marketplace. It allows you to place bids, list tokens for sale, cancel bids or listings, accept bids, buy tokens, create auctions, and accept the highest bid on an auction.

--- a/docs/pages/starter-kit/customization.md
+++ b/docs/pages/starter-kit/customization.md
@@ -1,5 +1,5 @@
 ---
-title: ‘Customization’
+title: 'Customization'
 ---
 
 # Customization


### PR DESCRIPTION
Core section did not had any title and the Customization in the starter kit section has some ' in the title