### PR TITLE
Fetch asset + ownership on polling

### DIFF
--- a/.changeset/smart-jeans-happen.md
+++ b/.changeset/smart-jeans-happen.md
@@ -1,0 +1,5 @@
+---
+'@liteflow/core': patch
+---
+
+Fetch ownership and asset when checking changes of ownership/minting

--- a/packages/core/queries/fetchQuantityOwned.graphql
+++ b/packages/core/queries/fetchQuantityOwned.graphql
@@ -1,5 +1,16 @@
-query FetchQuantityOwned($assetId: String!, $ownerAddress: Address!) {
-  ownership(assetId: $assetId, ownerAddress: $ownerAddress) {
-    quantity
+query FetchQuantityOwned(
+  $chainId: Int!
+  $collectionAddress: Address!
+  $tokenId: String!
+  $ownerAddress: Address!
+) {
+  asset(
+    chainId: $chainId
+    collectionAddress: $collectionAddress
+    tokenId: $tokenId
+  ) {
+    ownership(ownerAddress: $ownerAddress) {
+      quantity
+    }
   }
 }

--- a/packages/core/src/exchange/offerQuantityChanges.ts
+++ b/packages/core/src/exchange/offerQuantityChanges.ts
@@ -2,7 +2,6 @@ import { BigNumber } from '@ethersproject/bignumber'
 import invariant from 'ts-invariant'
 import type { Sdk } from '../graphql'
 import type { Address, ChainId, Uint256 } from '../types'
-import { toAssetId } from '../utils/convert'
 
 export async function checkOwnership(
   sdk: Sdk,
@@ -11,11 +10,13 @@ export async function checkOwnership(
   token: string,
   owner: Address,
 ): Promise<Uint256> {
-  const { ownership } = await sdk.FetchQuantityOwned({
-    assetId: toAssetId(chain, collection, token),
+  const { asset } = await sdk.FetchQuantityOwned({
+    chainId: chain,
+    collectionAddress: collection,
+    tokenId: token,
     ownerAddress: owner,
   })
-  return ownership?.quantity ?? '0'
+  return asset?.ownership?.quantity ?? '0'
 }
 
 export async function pollOwnership(


### PR DESCRIPTION
### Project organization

- Closes https://github.com/liteflow-labs/liteflow-js/issues/151

### Description

Fetch ownership and asset when checking changes of ownership/minting
In some cases, the ownership was created before the asset leading to some redirection to the asset page before it's even created.
This ensures both asset and ownership are tested before finalizing the action.

### How to test

1. Pack the library `npm pack -ws`
2. Checkout the starter kit
3. Install the packed version `npm i ../liteflow-js/liteflow-react-1.1.0.tgz ../liteflow-js/liteflow-core-1.1.0.tgz`
4. Mint an NFT and check that we don't have a 404
