### PR TITLE
Uncaught error for offer

### DIFF
--- a/.changeset/silver-trainers-approve.md
+++ b/.changeset/silver-trainers-approve.md
@@ -1,0 +1,5 @@
+---
+'@liteflow/react': patch
+---
+
+Ensure errors a caught when creating an offer

--- a/packages/react/src/useCreateOffer.ts
+++ b/packages/react/src/useCreateOffer.ts
@@ -88,8 +88,8 @@ export default function useCreateOffer(
       try {
         invariant(signer, ErrorMessages.SIGNER_FALSY)
 
-        if (type === 'SALE')
-          return client.exchange.listToken(
+        if (type === 'SALE') {
+          const listingId = await client.exchange.listToken(
             {
               chain,
               collection,
@@ -103,9 +103,11 @@ export default function useCreateOffer(
             signer,
             updateProgress,
           )
+          return listingId
+        }
         if (type === 'BUY') {
           invariant(unitPrice.currency)
-          return client.exchange.placeBid(
+          const bidId = await client.exchange.placeBid(
             {
               chain,
               collection,
@@ -120,6 +122,7 @@ export default function useCreateOffer(
             signer,
             updateProgress,
           )
+          return bidId
         }
 
         throw new Error(ErrorMessages.OFFER_CREATION_FAILED)


### PR DESCRIPTION
If an error occurred during the signature of an offer or even if a user cancels, the react sdk was not catching this error, thus not refreshing the step