### PR TITLE
remove unnecessary fields from FetchOffer query

### DIFF
--- a/.changeset/curly-poets-worry.md
+++ b/.changeset/curly-poets-worry.md
@@ -1,0 +1,5 @@
+---
+'@liteflow/core': patch
+---
+
+Remove unnecessary fields from `FetchOffer` query

--- a/packages/core/queries/fetchOffer.graphql
+++ b/packages/core/queries/fetchOffer.graphql
@@ -4,9 +4,7 @@ query FetchOffer($offerId: UUID!) {
     type
     makerAddress
     takerAddress
-    createdAt
     expiredAt
-    orderHash
     unitPrice
     availableQuantity
     asset {


### PR DESCRIPTION
### Description

I tried to remove `orderHash` from the API but this query is fetching it for no reason, so I remove it as well as `createdAt` that is also not used.
I kept `orderHash` on the API but will try to remove it in the future.

### Checklist

- [x] Update related changelogs <!-- Check [root's CHANGELOG.md](/CHANGELOG.md) to access the right changelogs -->