### PR TITLE
Add support for batch purchase

### DIFF
--- a/.changeset/big-dogs-change.md
+++ b/.changeset/big-dogs-change.md
@@ -1,0 +1,6 @@
+---
+'@liteflow/react': minor
+'@liteflow/core': minor
+---
+
+Add batch purchase feature to purchase multiple offers in a single transaction

--- a/docs/pages/tools/sdk-core/exchange.md
+++ b/docs/pages/tools/sdk-core/exchange.md
@@ -82,6 +82,19 @@ async buyToken(
 ): Promise<UUID>
 ```
 
+### batchPurchase
+
+This method allows you to purchase multiple listing.
+**Note:** The signer should already have approved the transfer of the tokens otherwise the transaction will fail.
+
+```ts
+async batchPurchase(
+  purchases: { listingId: UUID; quantity: Uint256 }[],
+  signer: Signer,
+  onProgress?: (state: AcceptOfferState) => void,
+): Promise<UUID>
+```
+
 ### createAuction
 
 This method allows you to create an auction.

--- a/docs/pages/tools/sdk-react/_meta.json
+++ b/docs/pages/tools/sdk-react/_meta.json
@@ -13,6 +13,7 @@
   },
   "useCreateOffer": "useCreateOffer",
   "useAcceptOffer": "useAcceptOffer",
+  "useBatchPurchase": "useBatchPurchase",
   "useCreateAuction": "useCreateAuction",
   "useAcceptAuction": "useAcceptAuction",
   "useCancelOffer": "useCancelOffer",

--- a/docs/pages/tools/sdk-react/useBatchPurchase.md
+++ b/docs/pages/tools/sdk-react/useBatchPurchase.md
@@ -1,0 +1,100 @@
+---
+title: 'useBatchPurchase'
+---
+
+# useBatchPurchase
+
+Hook to accept multiple offers, accessing the active process step as well as the transaction hash.
+**Note:** The signer should already have approved the transfer of the tokens otherwise the transaction will fail.
+
+## Usage
+
+```tsx
+import { BigNumber } from '@ethersproject/bignumber'
+import { BatchPurchaseStep, useBatchPurchase } from '@liteflow/react'
+
+export default function Component() {
+  const signer = undefined // type of "Signer & TypedDataSigner" Get the signer from the wallet. Need to be an Ethers Signer (https://docs.ethers.io/v5/api/signer/)
+  const [batchPurchase, { activeStep, transactionHash }] =
+    useBatchPurchase(signer)
+
+  const handleClick = async () => {
+    await batchPurchase([
+      {
+        offerId: '66710e28-38d4-11ed-a261-0242ac120002', // ID of the offer
+        quantity: BigNumber.from(1), // The quantity of NFT to accept. Must be 1 for erc721, must be inferior (partial fill) or equal to offer's quantity for erc1155.
+      },
+      {
+        offerId: '66710e28-38d4-11ed-a261-0242ac120003', // ID of the offer
+        quantity: BigNumber.from(1), // The quantity of NFT to accept. Must be 1 for erc721, must be inferior (partial fill) or equal to offer's quantity for erc1155.
+      },
+    ])
+  }
+
+  return (
+    <>
+      {activeStep === BatchPurchaseStep.INITIAL && (
+        <button onClick={handleClick}>Batch purchase</button>
+      )}
+      {activeStep === BatchPurchaseStep.TRANSACTION_SIGNATURE && (
+        <p>Please sign transaction in wallet</p>
+      )}
+      {activeStep === BatchPurchaseStep.TRANSACTION_PENDING && (
+        <p>Transaction is pending</p>
+      )}
+      {activeStep === BatchPurchaseStep.OWNERSHIP && <p>Verifying ownership</p>}
+      {transactionHash && <p>Transaction hash is {transactionHash}</p>}
+    </>
+  )
+}
+```
+
+## Configuration
+
+```tsx
+useBatchPurchase(
+  signer: Signer | undefined, // Ethers signer: https://docs.ethers.io/v5/api/signer/
+)
+```
+
+## Return values
+
+```tsx
+;[
+  (purchases: { offerId: string; quantity: BigNumberish }[]) => Promise<void>, // batchPurchase function to accept an purchase multiple offers
+  {
+    activeStep: AcceptOfferStep, // returns different values depending on the current acceptation step
+    transactionHash: string | undefined, // returns the transaction hash after transaction has been placed on the blockchain
+  },
+]
+```
+
+### acceptOffer
+
+Function to accept an offer for an NFT.
+
+Arguments:
+
+```tsx
+(
+  offerId: string, // Id of the offer
+  quantity: BigNumberish, // Quantity of asset to accept. Use BigNumber
+)
+```
+
+### activeStep
+
+The status of the transaction as an enum `BatchPurchaseStep` executed in this order. Once the offer acceptation has been complete the state returns to `BatchPurchaseStep.INITIAL`
+
+```tsx
+enum BatchPurchaseStep {
+  INITIAL, // Default
+  TRANSACTION_SIGNATURE, // Transaction has been initiated
+  TRANSACTION_PENDING, // Transaction is pending
+  OWNERSHIP, // Ownership is being verified
+}
+```
+
+### transactionHash
+
+The hash of the blockchain transaction of the accepted offer. This is only accessible after the approval of the transaction (after `BatchPurchaseStep.TRANSACTION_PENDING`)

--- a/docs/pages/tools/sdk-react/useBatchPurchase.md
+++ b/docs/pages/tools/sdk-react/useBatchPurchase.md
@@ -21,11 +21,11 @@ export default function Component() {
   const handleClick = async () => {
     await batchPurchase([
       {
-        offerId: '66710e28-38d4-11ed-a261-0242ac120002', // ID of the offer
+        listingId: '66710e28-38d4-11ed-a261-0242ac120002', // ID of the offer
         quantity: BigNumber.from(1), // The quantity of NFT to accept. Must be 1 for erc721, must be inferior (partial fill) or equal to offer's quantity for erc1155.
       },
       {
-        offerId: '66710e28-38d4-11ed-a261-0242ac120003', // ID of the offer
+        listingId: '66710e28-38d4-11ed-a261-0242ac120003', // ID of the offer
         quantity: BigNumber.from(1), // The quantity of NFT to accept. Must be 1 for erc721, must be inferior (partial fill) or equal to offer's quantity for erc1155.
       },
     ])
@@ -69,16 +69,18 @@ useBatchPurchase(
 ]
 ```
 
-### acceptOffer
+### batchPurchase
 
-Function to accept an offer for an NFT.
+Function to accept multiple offers.
 
 Arguments:
 
 ```tsx
 (
-  offerId: string, // Id of the offer
-  quantity: BigNumberish, // Quantity of asset to accept. Use BigNumber
+  purchases: {
+    listingId: string, // Id of the offer
+    quantity: BigNumberish, // Quantity of asset to accept. Use BigNumber
+  }[]
 )
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4827,9 +4827,9 @@
       "dev": true
     },
     "node_modules/@nft/api-graphql": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/@nft/api-graphql/-/api-graphql-1.0.0-beta.33.tgz",
-      "integrity": "sha512-w4WveZLiq99z/yz5XlP7OjW9va0LKkz58vtY8g2UvQzEHf01yjQTm7bG0l6vvGi4ktIo5qk/Hj8VZlQgvEsy3Q==",
+      "version": "1.0.0-beta.46.2",
+      "resolved": "https://registry.npmjs.org/@nft/api-graphql/-/api-graphql-1.0.0-beta.46.2.tgz",
+      "integrity": "sha512-zuhbQ6xlvXuwElRawKGK89DbR+xcX3OOhjZJA3H0iQY/WlpPOSPOeJZEcEBStWhTh9I5a/mNh555ghPEDVxRLg==",
       "dev": true
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -16226,7 +16226,7 @@
         "@graphql-codegen/typescript": "^1.23.0",
         "@graphql-codegen/typescript-graphql-request": "^4.5.5",
         "@graphql-codegen/typescript-operations": "^1.18.4",
-        "@nft/api-graphql": "^1.0.0-beta.33"
+        "@nft/api-graphql": "^1.0.0-beta.46.2"
       },
       "peerDependencies": {
         "ethers": "^5.6.1"
@@ -19943,7 +19943,7 @@
         "@graphql-codegen/typescript": "^1.23.0",
         "@graphql-codegen/typescript-graphql-request": "^4.5.5",
         "@graphql-codegen/typescript-operations": "^1.18.4",
-        "@nft/api-graphql": "^1.0.0-beta.33",
+        "@nft/api-graphql": "^1.0.0-beta.46.2",
         "graphql-request": "^5.0.0",
         "ts-invariant": "^0.9.4"
       }
@@ -20067,9 +20067,9 @@
       "dev": true
     },
     "@nft/api-graphql": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/@nft/api-graphql/-/api-graphql-1.0.0-beta.33.tgz",
-      "integrity": "sha512-w4WveZLiq99z/yz5XlP7OjW9va0LKkz58vtY8g2UvQzEHf01yjQTm7bG0l6vvGi4ktIo5qk/Hj8VZlQgvEsy3Q==",
+      "version": "1.0.0-beta.46.2",
+      "resolved": "https://registry.npmjs.org/@nft/api-graphql/-/api-graphql-1.0.0-beta.46.2.tgz",
+      "integrity": "sha512-zuhbQ6xlvXuwElRawKGK89DbR+xcX3OOhjZJA3H0iQY/WlpPOSPOeJZEcEBStWhTh9I5a/mNh555ghPEDVxRLg==",
       "dev": true
     },
     "@nodelib/fs.scandir": {

--- a/packages/core/codegen.yml
+++ b/packages/core/codegen.yml
@@ -1,5 +1,4 @@
-# schema: '../../node_modules/@nft/api-graphql/schema.graphql'
-schema: https://staging.api.liteflow.com/e921d000-de68-47fc-beea-e428971ba509/graphql
+schema: '../../node_modules/@nft/api-graphql/schema.graphql'
 documents:
   - './fragments/*.graphql'
   - './queries/*.graphql'

--- a/packages/core/codegen.yml
+++ b/packages/core/codegen.yml
@@ -1,4 +1,5 @@
-schema: '../../node_modules/@nft/api-graphql/schema.graphql'
+# schema: '../../node_modules/@nft/api-graphql/schema.graphql'
+schema: https://staging.api.liteflow.com/e921d000-de68-47fc-beea-e428971ba509/graphql
 documents:
   - './fragments/*.graphql'
   - './queries/*.graphql'

--- a/packages/core/mutations/createBatchPurchaseTransaction.graphql
+++ b/packages/core/mutations/createBatchPurchaseTransaction.graphql
@@ -1,0 +1,14 @@
+mutation CreateBatchPurchaseTransaction(
+  $accountAddress: Address!
+  $items: [CreateCheckoutTransactionItemInput!]!
+) {
+  createCheckoutTransaction(accountAddress: $accountAddress, items: $items) {
+    transaction {
+      to
+      from
+      data
+      gasPrice
+      value
+    }
+  }
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,6 +29,6 @@
     "@graphql-codegen/typescript": "^1.23.0",
     "@graphql-codegen/typescript-graphql-request": "^4.5.5",
     "@graphql-codegen/typescript-operations": "^1.18.4",
-    "@nft/api-graphql": "^1.0.0-beta.33"
+    "@nft/api-graphql": "^1.0.0-beta.46.2"
   }
 }

--- a/packages/core/src/exchange/batchPurchase.ts
+++ b/packages/core/src/exchange/batchPurchase.ts
@@ -1,0 +1,78 @@
+import { BigNumber, type Signer } from 'ethers'
+import { invariant } from 'ts-invariant'
+import type { FetchOfferQuery, Sdk } from '../graphql'
+import type { IState, TransactionHash, UUID, Uint256 } from '../types'
+import { toAddress, toTransactionHash } from '../utils/convert'
+import { sendTransaction } from '../utils/transaction'
+import { checkOwnership, pollOwnership } from './offerQuantityChanges'
+import { checkOfferValidity } from './utils'
+
+export type State =
+  | IState<'OFFER_VALIDITY', {}>
+  | IState<'TRANSACTION_SIGNATURE', {}>
+  | IState<'TRANSACTION_PENDING', { txHash: TransactionHash }>
+  | IState<'OWNERSHIP', {}>
+
+export async function batchPurchase(
+  sdk: Sdk,
+  purchases: { listingId: UUID; quantity: Uint256 }[],
+  signer: Signer,
+  onProgress?: (state: State) => void,
+): Promise<UUID[]> {
+  const address = await signer.getAddress()
+
+  const offersAndQuantities: {
+    offer: NonNullable<FetchOfferQuery['offer']>
+    quantity: Uint256
+  }[] = []
+  onProgress?.({ type: 'OFFER_VALIDITY', payload: {} })
+  for (const { listingId, quantity } of purchases) {
+    const { offer } = await sdk.FetchOffer({ offerId: listingId })
+    invariant(offer, "Can't find offer")
+
+    await checkOfferValidity(offer, toAddress(address))
+    offersAndQuantities.push({ offer, quantity })
+  }
+
+  const {
+    createCheckoutTransaction: { transaction },
+  } = await sdk.CreateBatchPurchaseTransaction({
+    accountAddress: toAddress(address),
+    items: offersAndQuantities.map(({ offer, quantity }) => ({
+      offerId: offer.id,
+      fillQuantity: BigNumber.from(quantity || 1).toString(),
+    })),
+  })
+
+  const firstOffer = offersAndQuantities[0]?.offer
+  invariant(firstOffer, "Can't find offer")
+
+  const initialQuantity = await checkOwnership(
+    sdk,
+    firstOffer.asset.collection.chainId,
+    firstOffer.asset.collection.address,
+    firstOffer.asset.tokenId,
+    toAddress(address),
+  )
+
+  onProgress?.({ type: 'TRANSACTION_SIGNATURE', payload: {} })
+  const tx = await sendTransaction(signer, transaction)
+
+  onProgress?.({
+    type: 'TRANSACTION_PENDING',
+    payload: { txHash: toTransactionHash(tx.hash) },
+  })
+  await tx.wait()
+
+  onProgress?.({ type: 'OWNERSHIP', payload: {} })
+  await pollOwnership(
+    sdk,
+    firstOffer.asset.collection.chainId,
+    firstOffer.asset.collection.address,
+    firstOffer.asset.tokenId,
+    toAddress(address),
+    initialQuantity,
+  )
+
+  return offersAndQuantities.map(({ offer }) => offer.id)
+}

--- a/packages/core/src/exchange/index.ts
+++ b/packages/core/src/exchange/index.ts
@@ -6,6 +6,7 @@ import type { State as AcceptAuctionHighestBidState } from './acceptAuctionHighe
 import { acceptAuctionHighestBid } from './acceptAuctionHighestBid'
 import type { State as AcceptOfferState } from './acceptOffer'
 import { acceptOffer } from './acceptOffer'
+import { batchPurchase } from './batchPurchase'
 import type { State as CancelOfferState } from './cancelOffer'
 import { cancelOffer } from './cancelOffer'
 import type { Auction } from './createAuction'
@@ -114,6 +115,22 @@ export class Exchange {
     onProgress?: (state: AcceptOfferState) => void,
   ): Promise<UUID> {
     return acceptOffer(this.sdk, listingId, quantity, signer, onProgress)
+  }
+
+  /**
+   * Accept multiple listings
+   * The signer should already have approved the transfer of the tokens otherwise the transaction will fail
+   * @param {Array<{ listingId: UUID, quantity: Uint256 }>} purchases - The listings to accept
+   * @param {Signer} signer - The signer to use to accept the listings
+   * @param {(state: AcceptOfferState) => void} onProgress - Callback to track the acceptance progress
+   * @returns {Promise<UUID[]>} The IDs of the accepted listings
+   */
+  async batchPurchase(
+    purchases: { listingId: UUID; quantity: Uint256 }[],
+    signer: Signer,
+    onProgress?: (state: AcceptOfferState) => void,
+  ): Promise<UUID[]> {
+    return batchPurchase(this.sdk, purchases, signer, onProgress)
   }
 
   /**

--- a/packages/core/src/exchange/utils.ts
+++ b/packages/core/src/exchange/utils.ts
@@ -1,0 +1,26 @@
+import { BigNumber } from 'ethers'
+import type { FetchOfferQuery } from '../graphql'
+import type { Address } from '../types'
+import { toAddress } from '../utils/convert'
+
+export const checkOfferValidity = async (
+  offer: NonNullable<FetchOfferQuery['offer']>,
+  taker: Address,
+) => {
+  if (offer.expiredAt && new Date(offer.expiredAt) < new Date())
+    throw new Error('Offer has expired')
+
+  if (BigNumber.from(offer.availableQuantity).isZero())
+    throw new Error('Offer is not available')
+
+  if (offer.takerAddress && toAddress(offer.takerAddress) !== taker)
+    throw new Error('Offer is not for you')
+
+  if (toAddress(offer.makerAddress) === toAddress(taker))
+    throw new Error('You can not accept your own offer')
+
+  // TODO: Check if the maker still has the asset
+  // TODO: Check if the maker has authorized the transfer
+
+  // Except front running, the offer should be valid at this point
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -2,6 +2,7 @@ import useAcceptAuction, { AcceptAuctionStep } from './useAcceptAuction'
 import useAcceptOffer, { AcceptOfferStep } from './useAcceptOffer'
 import useAuctionStatus from './useAuctionStatus'
 import useAuthenticate from './useAuthenticate'
+import useBatchPurchase from './useBatchPurchase'
 import useCancelOffer, { CancelOfferStep } from './useCancelOffer'
 import useCreateAuction from './useCreateAuction'
 import useCreateNFT, { CreateNftStep } from './useCreateNFT'
@@ -24,6 +25,7 @@ export {
   useAcceptAuction,
   useAcceptOffer,
   useAuctionStatus,
+  useBatchPurchase,
   useCancelOffer,
   useCreateAuction,
   useCreateOffer,

--- a/packages/react/src/useBatchPurchase.ts
+++ b/packages/react/src/useBatchPurchase.ts
@@ -1,0 +1,78 @@
+import { Signer } from '@ethersproject/abstract-signer'
+import { BigNumberish } from '@ethersproject/bignumber'
+import { TransactionHash, UUID } from '@liteflow/core'
+import { useCallback, useContext, useState } from 'react'
+import invariant from 'ts-invariant'
+import { LiteflowContext } from './context'
+import { ErrorMessages } from './errorMessages'
+
+export enum BatchPurchaseStep {
+  INITIAL,
+  TRANSACTION_SIGNATURE,
+  TRANSACTION_PENDING,
+  OWNERSHIP,
+}
+
+type batchPurchaseFn = (
+  purchases: { offerId: UUID; quantity: BigNumberish }[],
+) => Promise<void>
+
+export default function useBatchPurchase(signer: Signer | undefined): [
+  batchPurchaseFn,
+  {
+    activeStep: BatchPurchaseStep
+    transactionHash: TransactionHash | undefined
+  },
+] {
+  const { client } = useContext(LiteflowContext)
+  const [activeStep, setActiveProcess] = useState<BatchPurchaseStep>(
+    BatchPurchaseStep.INITIAL,
+  )
+  const [transactionHash, setTransactionHash] = useState<TransactionHash>()
+
+  const onProgress = useCallback(
+    (state) => {
+      switch (state.type) {
+        case 'TRANSACTION_SIGNATURE': {
+          setActiveProcess(BatchPurchaseStep.TRANSACTION_PENDING)
+          break
+        }
+        case 'TRANSACTION_PENDING': {
+          setActiveProcess(BatchPurchaseStep.TRANSACTION_PENDING)
+          setTransactionHash(state.payload.txHash)
+          break
+        }
+        case 'OWNERSHIP': {
+          setActiveProcess(BatchPurchaseStep.OWNERSHIP)
+          break
+        }
+        case 'OFFER_VALIDITY': {
+          console.log('validating offer...')
+        }
+      }
+    },
+    [setActiveProcess, setTransactionHash],
+  )
+
+  const batchPurchase: batchPurchaseFn = useCallback(
+    async (purchases) => {
+      invariant(signer, ErrorMessages.SIGNER_FALSY)
+      try {
+        await client.exchange.batchPurchase(
+          purchases.map((x) => ({
+            listingId: x.offerId,
+            quantity: x.quantity,
+          })),
+          signer,
+          onProgress,
+        )
+      } finally {
+        setActiveProcess(BatchPurchaseStep.INITIAL)
+        setTransactionHash(undefined)
+      }
+    },
+    [client, signer, onProgress],
+  )
+
+  return [batchPurchase, { activeStep, transactionHash }]
+}


### PR DESCRIPTION
Add batch purchase feature to purchase multiple offers in a single transaction

on `@liteflow/core` use the `client.exchange.batchPurchase` function
on `@liteflow/react` use `useBatchPurchase` hook