### PR TITLE
Split useInvitation into two

### DIFF
--- a/.changeset/unlucky-crews-deny.md
+++ b/.changeset/unlucky-crews-deny.md
@@ -1,0 +1,5 @@
+---
+'@liteflow/react': patch
+---
+
+Split useInvitation into two

--- a/example/package.json
+++ b/example/package.json
@@ -9,8 +9,8 @@
     "lint": "next lint && prettier \"**/*.{ts,tsx,json,md}\" --check"
   },
   "dependencies": {
-    "@liteflow/core": "file:../liteflow-core-1.3.0.tgz",
-    "@liteflow/react": "file:../liteflow-react-1.3.0.tgz",
+    "@liteflow/core": "file:../liteflow-core-2.0.0.tgz",
+    "@liteflow/react": "file:../liteflow-react-2.0.0.tgz",
     "ethers": "^5.7.2",
     "next": "^13.5.4",
     "react": "^18.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16211,7 +16211,7 @@
     },
     "packages/core": {
       "name": "@liteflow/core",
-      "version": "1.3.0",
+      "version": "2.0.0",
       "dependencies": {
         "@ethersproject/abstract-provider": "^5.7.0",
         "@ethersproject/abstract-signer": "^5.7.0",
@@ -16233,7 +16233,7 @@
     },
     "packages/react": {
       "name": "@liteflow/react",
-      "version": "1.3.0",
+      "version": "2.0.0",
       "dependencies": {
         "@ethersproject/abstract-signer": "^5.0.14",
         "@ethersproject/bignumber": "^5.5.0",

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,10 +1,11 @@
+import useAcceptInvitation from './useAcceptInvitation'
 import useAcceptOffer, { AcceptOfferStep } from './useAcceptOffer'
 import useAuthenticate from './useAuthenticate'
 import useBatchPurchase, { BatchPurchaseStep } from './useBatchPurchase'
 import useCancelOffer, { CancelOfferStep } from './useCancelOffer'
+import useCreateInvitation from './useCreateInvitation'
 import useCreateNFT, { CreateNftStep } from './useCreateNFT'
 import useCreateOffer, { CreateOfferStep } from './useCreateOffer'
-import useInvitation from './useInvitation'
 import useIsLoggedIn from './useIsLoggedIn'
 import useMintDrop, { MintDropStep } from './useMintDrop'
 import useUpdateAccount from './useUpdateAccount'
@@ -29,7 +30,12 @@ export {
 export { CreateNftStep, MintDropStep, useCreateNFT, useMintDrop }
 
 // Account
-export { useInvitation, useUpdateAccount, useVerifyAccount }
+export {
+  useAcceptInvitation,
+  useCreateInvitation,
+  useUpdateAccount,
+  useVerifyAccount,
+}
 
 // Auth
 export { useAuthenticate, useIsLoggedIn }

--- a/packages/react/src/useAcceptInvitation.ts
+++ b/packages/react/src/useAcceptInvitation.ts
@@ -18,13 +18,15 @@ export default function useAcceptInvitation(): {
   accept: (invitationId: string) => Promise<string>
   accepting: boolean
 } {
-  const { sdk } = useContext(LiteflowContext)
+  const { sdk, resetAuthenticationToken } = useContext(LiteflowContext)
   const [accepting, setAccepting] = useState(false)
 
   const accept = useCallback(
     async (invitationId: string) => {
       try {
         setAccepting(true)
+        // Ensure that there is no token in the context
+        resetAuthenticationToken()
         const { acceptInvitation } = await sdk.AcceptInvitation({
           id: invitationId,
         })
@@ -37,7 +39,7 @@ export default function useAcceptInvitation(): {
         setAccepting(false)
       }
     },
-    [sdk],
+    [resetAuthenticationToken, sdk],
   )
 
   return { accept, accepting }

--- a/packages/react/src/useAcceptInvitation.ts
+++ b/packages/react/src/useAcceptInvitation.ts
@@ -1,0 +1,44 @@
+import { gql } from 'graphql-request'
+import { useCallback, useContext, useState } from 'react'
+import invariant from 'ts-invariant'
+import { LiteflowContext } from './context'
+import { ErrorMessages } from './errorMessages'
+
+gql`
+  mutation AcceptInvitation($id: UUID!) {
+    acceptInvitation(input: { id: $id }) {
+      invitation {
+        id
+      }
+    }
+  }
+`
+
+export default function useAcceptInvitation(): {
+  accept: (invitationId: string) => Promise<string>
+  accepting: boolean
+} {
+  const { sdk } = useContext(LiteflowContext)
+  const [accepting, setAccepting] = useState(false)
+
+  const accept = useCallback(
+    async (invitationId: string) => {
+      try {
+        setAccepting(true)
+        const { acceptInvitation } = await sdk.AcceptInvitation({
+          id: invitationId,
+        })
+        invariant(
+          acceptInvitation?.invitation,
+          ErrorMessages.INVITATION_NOT_FOUND,
+        )
+        return acceptInvitation.invitation.id
+      } finally {
+        setAccepting(false)
+      }
+    },
+    [sdk],
+  )
+
+  return { accept, accepting }
+}

--- a/packages/react/src/useCreateInvitation.ts
+++ b/packages/react/src/useCreateInvitation.ts
@@ -16,16 +16,6 @@ gql`
 `
 
 gql`
-  mutation AcceptInvitation($id: UUID!) {
-    acceptInvitation(input: { id: $id }) {
-      invitation {
-        id
-      }
-    }
-  }
-`
-
-gql`
   query GetInvitation($address: Address!) {
     invitationByInvitedByAddress(invitedByAddress: $address) {
       id
@@ -33,15 +23,13 @@ gql`
   }
 `
 
-export default function useInvitation(signer: Signer | undefined): {
+export default function useCreateInvitation(signer: Signer | undefined): {
   create: () => Promise<string>
-  accept: (invitationId: string) => Promise<string>
-  accepting: boolean
   creating: boolean
 } {
   const { sdk } = useContext(LiteflowContext)
-  const [accepting, setAccepting] = useState(false)
   const [creating, setCreating] = useState(false)
+
   const create = useCallback(async () => {
     invariant(signer, ErrorMessages.SIGNER_FALSY)
     try {
@@ -63,24 +51,5 @@ export default function useInvitation(signer: Signer | undefined): {
     }
   }, [sdk, signer])
 
-  const accept = useCallback(
-    async (invitationId: string) => {
-      try {
-        setAccepting(true)
-        const { acceptInvitation } = await sdk.AcceptInvitation({
-          id: invitationId,
-        })
-        invariant(
-          acceptInvitation?.invitation,
-          ErrorMessages.INVITATION_NOT_FOUND,
-        )
-        return acceptInvitation.invitation.id
-      } finally {
-        setAccepting(false)
-      }
-    },
-    [sdk],
-  )
-
-  return { create, accept, accepting, creating }
+  return { create, creating }
 }


### PR DESCRIPTION
### Project organization
- Related [trello card](https://trello.com/c/cPl7yMm8/1178-issue-referral-system?filter=member:ismailtoyran)

### Description
Split `useInvitation` into two.
So user can use `useCreateInvitation` with `signer` required and `useAcceptInvitation` without.
