### PR TITLE
Use createCancelOfferTransaction instead of deprecated offer.cancel.

### DIFF
--- a/.changeset/happy-colts-walk.md
+++ b/.changeset/happy-colts-walk.md
@@ -1,0 +1,5 @@
+---
+'@liteflow/core': patch
+---
+
+Use mutation `createCancelOfferTransaction` instead of deprecated query `offer.cancel`

--- a/packages/core/mutations/cancelOfferTransaction.graphql
+++ b/packages/core/mutations/cancelOfferTransaction.graphql
@@ -1,7 +1,7 @@
 # This query should use the mutation `cancelOfferTransaction` to cancel an offer
-query OfferWithCancel($offerId: UUID!, $account: Address!) {
-  offer(id: $offerId) {
-    cancel(account: $account) {
+mutation CreateCancelOfferTransaction($offerId: String!, $account: Address!) {
+  createCancelOfferTransaction(offerId: $offerId, accountAddress: $account) {
+    transaction {
       ...Transaction
     }
   }

--- a/packages/core/mutations/cancelOfferTransaction.graphql
+++ b/packages/core/mutations/cancelOfferTransaction.graphql
@@ -1,4 +1,3 @@
-# This query should use the mutation `cancelOfferTransaction` to cancel an offer
 mutation CreateCancelOfferTransaction($offerId: String!, $account: Address!) {
   createCancelOfferTransaction(offerId: $offerId, accountAddress: $account) {
     transaction {

--- a/packages/core/src/exchange/cancelOffer.ts
+++ b/packages/core/src/exchange/cancelOffer.ts
@@ -16,14 +16,18 @@ export async function cancelOffer(
 ): Promise<UUID> {
   const address = await signer.getAddress()
 
-  const { offer } = await sdk.OfferWithCancel({
-    offerId,
-    account: toAddress(address),
-  })
-  if (!offer) throw new Error("Can't find offer")
+  const { createCancelOfferTransaction } =
+    await sdk.CreateCancelOfferTransaction({
+      offerId,
+      account: toAddress(address),
+    })
+  if (!createCancelOfferTransaction) throw new Error("Can't find offer")
 
   onProgress?.({ type: 'TRANSACTION_SIGNATURE', payload: {} })
-  const tx = await sendTransaction(signer, offer.cancel)
+  const tx = await sendTransaction(
+    signer,
+    createCancelOfferTransaction.transaction,
+  )
 
   onProgress?.({
     type: 'TRANSACTION_PENDING',


### PR DESCRIPTION
### Description

Use mutation `createCancelOfferTransaction` instead of deprecated query `offer.cancel`.

### Checklist

- [x] Update related changelogs <!-- Check [root's CHANGELOG.md](/CHANGELOG.md) to access the right changelogs -->
