### PR TITLE
Use new queries `listing` and `openOffer` instead of now deprecated `offer`

### DIFF
--- a/.changeset/happy-ears-hammer.md
+++ b/.changeset/happy-ears-hammer.md
@@ -1,0 +1,5 @@
+---
+'@liteflow/core': patch
+---
+
+Use new queries `listing` and `openOffer` instead of now deprecated `offer`

--- a/package-lock.json
+++ b/package-lock.json
@@ -4827,9 +4827,9 @@
       "dev": true
     },
     "node_modules/@nft/api-graphql": {
-      "version": "1.0.0-beta.46.2",
-      "resolved": "https://registry.npmjs.org/@nft/api-graphql/-/api-graphql-1.0.0-beta.46.2.tgz",
-      "integrity": "sha512-zuhbQ6xlvXuwElRawKGK89DbR+xcX3OOhjZJA3H0iQY/WlpPOSPOeJZEcEBStWhTh9I5a/mNh555ghPEDVxRLg==",
+      "version": "1.0.0-beta.52-prerelease-8",
+      "resolved": "https://registry.npmjs.org/@nft/api-graphql/-/api-graphql-1.0.0-beta.52-prerelease-8.tgz",
+      "integrity": "sha512-F4MnLFPARVbWOnLEL1aF+Vha4m59/GCvEEv1pGOE+u/GJPwPV+nEfkdkjrFOXeugsmx4VKiFpXC2d/t01Zwe1Q==",
       "dev": true
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -16211,7 +16211,7 @@
     },
     "packages/core": {
       "name": "@liteflow/core",
-      "version": "1.3.0",
+      "version": "2.0.0",
       "dependencies": {
         "@ethersproject/abstract-provider": "^5.7.0",
         "@ethersproject/abstract-signer": "^5.7.0",
@@ -16225,7 +16225,7 @@
         "@graphql-codegen/typescript": "^1.23.0",
         "@graphql-codegen/typescript-graphql-request": "^4.5.5",
         "@graphql-codegen/typescript-operations": "^1.18.4",
-        "@nft/api-graphql": "^1.0.0-beta.46.2"
+        "@nft/api-graphql": "^1.0.0-beta.52-prerelease-8"
       },
       "peerDependencies": {
         "ethers": "^5.6.1"
@@ -16233,7 +16233,7 @@
     },
     "packages/react": {
       "name": "@liteflow/react",
-      "version": "1.3.0",
+      "version": "2.0.0",
       "dependencies": {
         "@ethersproject/abstract-signer": "^5.0.14",
         "@ethersproject/bignumber": "^5.5.0",
@@ -19943,7 +19943,7 @@
         "@graphql-codegen/typescript": "^1.23.0",
         "@graphql-codegen/typescript-graphql-request": "^4.5.5",
         "@graphql-codegen/typescript-operations": "^1.18.4",
-        "@nft/api-graphql": "^1.0.0-beta.46.2",
+        "@nft/api-graphql": "^1.0.0-beta.52-prerelease-8",
         "graphql-request": "^5.0.0",
         "graphql-tag": "^2.12.6",
         "ts-invariant": "^0.9.4"
@@ -20069,9 +20069,9 @@
       "dev": true
     },
     "@nft/api-graphql": {
-      "version": "1.0.0-beta.46.2",
-      "resolved": "https://registry.npmjs.org/@nft/api-graphql/-/api-graphql-1.0.0-beta.46.2.tgz",
-      "integrity": "sha512-zuhbQ6xlvXuwElRawKGK89DbR+xcX3OOhjZJA3H0iQY/WlpPOSPOeJZEcEBStWhTh9I5a/mNh555ghPEDVxRLg==",
+      "version": "1.0.0-beta.52-prerelease-8",
+      "resolved": "https://registry.npmjs.org/@nft/api-graphql/-/api-graphql-1.0.0-beta.52-prerelease-8.tgz",
+      "integrity": "sha512-F4MnLFPARVbWOnLEL1aF+Vha4m59/GCvEEv1pGOE+u/GJPwPV+nEfkdkjrFOXeugsmx4VKiFpXC2d/t01Zwe1Q==",
       "dev": true
     },
     "@nodelib/fs.scandir": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4827,9 +4827,9 @@
       "dev": true
     },
     "node_modules/@nft/api-graphql": {
-      "version": "1.0.0-beta.52-prerelease-8",
-      "resolved": "https://registry.npmjs.org/@nft/api-graphql/-/api-graphql-1.0.0-beta.52-prerelease-8.tgz",
-      "integrity": "sha512-F4MnLFPARVbWOnLEL1aF+Vha4m59/GCvEEv1pGOE+u/GJPwPV+nEfkdkjrFOXeugsmx4VKiFpXC2d/t01Zwe1Q==",
+      "version": "1.0.0-beta.52",
+      "resolved": "https://registry.npmjs.org/@nft/api-graphql/-/api-graphql-1.0.0-beta.52.tgz",
+      "integrity": "sha512-YX2AgQo2jeyFO/Rg+7E5E1iqoM8uzZgsgm+Tq/9zWbTjhad5aY9pxKsdH8zuZfhR6NDCpsHypOjEX1mScsoCLQ==",
       "dev": true
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -16231,12 +16231,6 @@
         "ethers": "^5.6.1"
       }
     },
-    "packages/core/node_modules/@nft/api-graphql": {
-      "version": "1.0.0-beta.52",
-      "resolved": "https://registry.npmjs.org/@nft/api-graphql/-/api-graphql-1.0.0-beta.52.tgz",
-      "integrity": "sha512-YX2AgQo2jeyFO/Rg+7E5E1iqoM8uzZgsgm+Tq/9zWbTjhad5aY9pxKsdH8zuZfhR6NDCpsHypOjEX1mScsoCLQ==",
-      "dev": true
-    },
     "packages/react": {
       "name": "@liteflow/react",
       "version": "2.0.0",
@@ -19953,14 +19947,6 @@
         "graphql-request": "^5.0.0",
         "graphql-tag": "^2.12.6",
         "ts-invariant": "^0.9.4"
-      },
-      "dependencies": {
-        "@nft/api-graphql": {
-          "version": "1.0.0-beta.52",
-          "resolved": "https://registry.npmjs.org/@nft/api-graphql/-/api-graphql-1.0.0-beta.52.tgz",
-          "integrity": "sha512-YX2AgQo2jeyFO/Rg+7E5E1iqoM8uzZgsgm+Tq/9zWbTjhad5aY9pxKsdH8zuZfhR6NDCpsHypOjEX1mScsoCLQ==",
-          "dev": true
-        }
       }
     },
     "@liteflow/react": {
@@ -20083,9 +20069,9 @@
       "dev": true
     },
     "@nft/api-graphql": {
-      "version": "1.0.0-beta.52-prerelease-8",
-      "resolved": "https://registry.npmjs.org/@nft/api-graphql/-/api-graphql-1.0.0-beta.52-prerelease-8.tgz",
-      "integrity": "sha512-F4MnLFPARVbWOnLEL1aF+Vha4m59/GCvEEv1pGOE+u/GJPwPV+nEfkdkjrFOXeugsmx4VKiFpXC2d/t01Zwe1Q==",
+      "version": "1.0.0-beta.52",
+      "resolved": "https://registry.npmjs.org/@nft/api-graphql/-/api-graphql-1.0.0-beta.52.tgz",
+      "integrity": "sha512-YX2AgQo2jeyFO/Rg+7E5E1iqoM8uzZgsgm+Tq/9zWbTjhad5aY9pxKsdH8zuZfhR6NDCpsHypOjEX1mScsoCLQ==",
       "dev": true
     },
     "@nodelib/fs.scandir": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16225,11 +16225,17 @@
         "@graphql-codegen/typescript": "^1.23.0",
         "@graphql-codegen/typescript-graphql-request": "^4.5.5",
         "@graphql-codegen/typescript-operations": "^1.18.4",
-        "@nft/api-graphql": "^1.0.0-beta.52-prerelease-8"
+        "@nft/api-graphql": "^1.0.0-beta.52"
       },
       "peerDependencies": {
         "ethers": "^5.6.1"
       }
+    },
+    "packages/core/node_modules/@nft/api-graphql": {
+      "version": "1.0.0-beta.52",
+      "resolved": "https://registry.npmjs.org/@nft/api-graphql/-/api-graphql-1.0.0-beta.52.tgz",
+      "integrity": "sha512-YX2AgQo2jeyFO/Rg+7E5E1iqoM8uzZgsgm+Tq/9zWbTjhad5aY9pxKsdH8zuZfhR6NDCpsHypOjEX1mScsoCLQ==",
+      "dev": true
     },
     "packages/react": {
       "name": "@liteflow/react",
@@ -19943,10 +19949,18 @@
         "@graphql-codegen/typescript": "^1.23.0",
         "@graphql-codegen/typescript-graphql-request": "^4.5.5",
         "@graphql-codegen/typescript-operations": "^1.18.4",
-        "@nft/api-graphql": "^1.0.0-beta.52-prerelease-8",
+        "@nft/api-graphql": "^1.0.0-beta.52",
         "graphql-request": "^5.0.0",
         "graphql-tag": "^2.12.6",
         "ts-invariant": "^0.9.4"
+      },
+      "dependencies": {
+        "@nft/api-graphql": {
+          "version": "1.0.0-beta.52",
+          "resolved": "https://registry.npmjs.org/@nft/api-graphql/-/api-graphql-1.0.0-beta.52.tgz",
+          "integrity": "sha512-YX2AgQo2jeyFO/Rg+7E5E1iqoM8uzZgsgm+Tq/9zWbTjhad5aY9pxKsdH8zuZfhR6NDCpsHypOjEX1mScsoCLQ==",
+          "dev": true
+        }
       }
     },
     "@liteflow/react": {

--- a/packages/core/fragments/offer.graphql
+++ b/packages/core/fragments/offer.graphql
@@ -1,5 +1,4 @@
-query FetchOffer($offerId: UUID!) {
-  offer(id: $offerId) {
+fragment Offer on Offer {
     id
     type
     makerAddress
@@ -18,5 +17,4 @@ query FetchOffer($offerId: UUID!) {
       chainId
       address
     }
-  }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,6 +30,6 @@
     "@graphql-codegen/typescript": "^1.23.0",
     "@graphql-codegen/typescript-graphql-request": "^4.5.5",
     "@graphql-codegen/typescript-operations": "^1.18.4",
-    "@nft/api-graphql": "^1.0.0-beta.52-prerelease-8"
+    "@nft/api-graphql": "^1.0.0-beta.52"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,6 +30,6 @@
     "@graphql-codegen/typescript": "^1.23.0",
     "@graphql-codegen/typescript-graphql-request": "^4.5.5",
     "@graphql-codegen/typescript-operations": "^1.18.4",
-    "@nft/api-graphql": "^1.0.0-beta.46.2"
+    "@nft/api-graphql": "^1.0.0-beta.52-prerelease-8"
   }
 }

--- a/packages/core/queries/fetchListing.graphql
+++ b/packages/core/queries/fetchListing.graphql
@@ -1,0 +1,5 @@
+query FetchListing($offerId: UUID!) {
+  listing(id: $offerId) {
+    ...Offer
+  }
+}

--- a/packages/core/queries/fetchOpenOffer.graphql
+++ b/packages/core/queries/fetchOpenOffer.graphql
@@ -1,0 +1,5 @@
+query FetchOpenOffer($offerId: UUID!) {
+  openOffer(id: $offerId) {
+    ...Offer
+  }
+}

--- a/packages/core/src/exchange/acceptOffer.ts
+++ b/packages/core/src/exchange/acceptOffer.ts
@@ -2,7 +2,7 @@ import type { TransactionResponse } from '@ethersproject/abstract-provider'
 import type { Signer } from 'ethers'
 import { BigNumber } from 'ethers'
 import { invariant } from 'ts-invariant'
-import type { FetchOfferQuery, Sdk } from '../graphql'
+import type { OfferFragment, Sdk } from '../graphql'
 import type { IState, TransactionHash, UUID, Uint256 } from '../types'
 import { toAddress, toTransactionHash } from '../utils/convert'
 import { sendTransaction } from '../utils/transaction'
@@ -21,7 +21,7 @@ export type State =
 
 const approveTransferTransaction = async (
   sdk: Sdk,
-  offer: FetchOfferQuery['offer'],
+  offer: OfferFragment,
   quantity: Uint256,
   signer: Signer,
 ): Promise<TransactionResponse | null> => {
@@ -57,8 +57,15 @@ export async function acceptOffer(
 ): Promise<UUID> {
   const address = await signer.getAddress()
 
-  const { offer } = await sdk.FetchOffer({ offerId })
-  invariant(offer, "Can't find offer")
+  let offer = undefined
+  const { listing } = await sdk.FetchListing({ offerId })
+  if (listing) {
+    offer = listing
+  } else {
+    const { openOffer } = await sdk.FetchOpenOffer({ offerId })
+    invariant(openOffer, "Can't find offer")
+    offer = openOffer
+  }
 
   onProgress?.({ type: 'OFFER_VALIDITY', payload: {} })
   await checkOfferValidity(offer, toAddress(address))

--- a/packages/core/src/exchange/acceptOffer.ts
+++ b/packages/core/src/exchange/acceptOffer.ts
@@ -50,22 +50,12 @@ const approveTransferTransaction = async (
 
 export async function acceptOffer(
   sdk: Sdk,
-  offerId: UUID,
+  offer: OfferFragment,
   quantity: Uint256,
   signer: Signer,
   onProgress?: (state: State) => void,
 ): Promise<UUID> {
   const address = await signer.getAddress()
-
-  let offer = undefined
-  const { listing } = await sdk.FetchListing({ offerId })
-  if (listing) {
-    offer = listing
-  } else {
-    const { openOffer } = await sdk.FetchOpenOffer({ offerId })
-    invariant(openOffer, "Can't find offer")
-    offer = openOffer
-  }
 
   onProgress?.({ type: 'OFFER_VALIDITY', payload: {} })
   await checkOfferValidity(offer, toAddress(address))

--- a/packages/core/src/exchange/batchPurchase.ts
+++ b/packages/core/src/exchange/batchPurchase.ts
@@ -1,6 +1,6 @@
 import { BigNumber, type Signer } from 'ethers'
 import { invariant } from 'ts-invariant'
-import type { FetchOfferQuery, Sdk } from '../graphql'
+import type { FetchListingQuery, Sdk } from '../graphql'
 import type { IState, TransactionHash, UUID, Uint256 } from '../types'
 import { toAddress, toTransactionHash } from '../utils/convert'
 import { sendTransaction } from '../utils/transaction'
@@ -22,12 +22,12 @@ export async function batchPurchase(
   const address = await signer.getAddress()
 
   const offersAndQuantities: {
-    offer: NonNullable<FetchOfferQuery['offer']>
+    offer: NonNullable<FetchListingQuery['listing']>
     quantity: Uint256
   }[] = []
   onProgress?.({ type: 'OFFER_VALIDITY', payload: {} })
   for (const { listingId, quantity } of purchases) {
-    const { offer } = await sdk.FetchOffer({ offerId: listingId })
+    const { listing: offer } = await sdk.FetchListing({ offerId: listingId })
     invariant(offer, "Can't find offer")
 
     await checkOfferValidity(offer, toAddress(address))

--- a/packages/core/src/exchange/index.ts
+++ b/packages/core/src/exchange/index.ts
@@ -94,7 +94,9 @@ export class Exchange {
     signer: Signer,
     onProgress?: (state: AcceptOfferState) => void,
   ): Promise<UUID> {
-    return acceptOffer(this.sdk, bidId, quantity, signer, onProgress)
+    const { openOffer } = await this.sdk.FetchOpenOffer({ offerId: bidId })
+    invariant(openOffer, "Offer doesn't exist")
+    return acceptOffer(this.sdk, openOffer, quantity, signer, onProgress)
   }
 
   /**
@@ -111,7 +113,9 @@ export class Exchange {
     signer: Signer,
     onProgress?: (state: AcceptOfferState) => void,
   ): Promise<UUID> {
-    return acceptOffer(this.sdk, listingId, quantity, signer, onProgress)
+    const { listing } = await this.sdk.FetchListing({ offerId: listingId })
+    invariant(listing, 'Listing not found')
+    return acceptOffer(this.sdk, listing, quantity, signer, onProgress)
   }
 
   /**

--- a/packages/core/src/exchange/index.ts
+++ b/packages/core/src/exchange/index.ts
@@ -1,6 +1,6 @@
 import type { Signer } from 'ethers'
 import invariant from 'ts-invariant'
-import type { FetchOfferQuery, Sdk } from '../graphql'
+import type { OfferFragment, Sdk } from '../graphql'
 import type { UUID, Uint256 } from '../types'
 import type { State as AcceptOfferState } from './acceptOffer'
 import { acceptOffer } from './acceptOffer'
@@ -132,11 +132,14 @@ export class Exchange {
 
   // Low level API to retrieve an offer
   // Offer can be either a bid or a listing
-  async getOffer(
-    offerId: UUID,
-  ): Promise<NonNullable<FetchOfferQuery['offer']>> {
-    const { offer } = await this.sdk.FetchOffer({ offerId })
-    invariant(offer, "Offer doesn't exist")
-    return offer
+  async getOffer(offerId: UUID): Promise<OfferFragment> {
+    const { listing } = await this.sdk.FetchListing({ offerId })
+    if (listing) {
+      return listing
+    }
+
+    const { openOffer } = await this.sdk.FetchOpenOffer({ offerId })
+    invariant(openOffer, "Offer doesn't exist")
+    return openOffer
   }
 }

--- a/packages/core/src/exchange/utils.ts
+++ b/packages/core/src/exchange/utils.ts
@@ -1,10 +1,10 @@
 import { BigNumber } from 'ethers'
-import type { FetchOfferQuery } from '../graphql'
+import type { OfferFragment } from '../graphql'
 import type { Address } from '../types'
 import { toAddress } from '../utils/convert'
 
 export const checkOfferValidity = async (
-  offer: NonNullable<FetchOfferQuery['offer']>,
+  offer: NonNullable<OfferFragment>,
   taker: Address,
 ) => {
   if (offer.expiredAt && new Date(offer.expiredAt) < new Date())


### PR DESCRIPTION
### Description

Use new queries `listing` and `openOffer` instead of now deprecated `offer`

### Checklist

- [x] Update related changelogs <!-- Check [root's CHANGELOG.md](/CHANGELOG.md) to access the right changelogs -->
