### PR TITLE
Remove deprecated params from offer creation

### DIFF
--- a/.changeset/calm-phones-fry.md
+++ b/.changeset/calm-phones-fry.md
@@ -1,0 +1,5 @@
+---
+'@liteflow/core': patch
+---
+
+Replace `assetId` by `chainId`, `collectionAddress` and `tokenId`, and deprecate `takerAddress` in `listToken` and `placeBid`.

--- a/packages/core/src/exchange/listToken.ts
+++ b/packages/core/src/exchange/listToken.ts
@@ -12,12 +12,7 @@ import type {
   UUID,
   Uint256,
 } from '../types'
-import {
-  toAddress,
-  toAssetId,
-  toCurrencyId,
-  toTransactionHash,
-} from '../utils/convert'
+import { toAddress, toCurrencyId, toTransactionHash } from '../utils/convert'
 import { signEIP712 } from '../utils/signature'
 import { approveCollection } from './approveCollection'
 
@@ -61,6 +56,7 @@ export type Listing = {
   /**
    * The address of the taker of the asset
    * @type Address
+   * @deprecated This parameter is not used anymore
    */
   taker?: Address
 
@@ -85,7 +81,6 @@ export async function listToken(
     token,
     unitPrice,
     quantity,
-    taker,
     expiredAt,
     metadata,
   }: Listing,
@@ -97,11 +92,12 @@ export async function listToken(
   const offer: OfferInputBis = {
     type: 'SALE',
     makerAddress: toAddress(address),
-    assetId: toAssetId(chain, collection, token),
+    chainId: chain,
+    collectionAddress: collection,
+    tokenId: token,
     currencyId: toCurrencyId(chain, unitPrice.currency),
     unitPrice: BigNumber.from(unitPrice.amount).toString(),
     quantity: BigNumber.from(quantity || '1').toString(),
-    takerAddress: taker,
     expiredAt: expiredAt ? expiredAt.toISOString() : undefined,
     metadata: metadata,
   }

--- a/packages/core/src/exchange/placeBid.ts
+++ b/packages/core/src/exchange/placeBid.ts
@@ -11,12 +11,7 @@ import type {
   UUID,
   Uint256,
 } from '../types'
-import {
-  toAddress,
-  toAssetId,
-  toCurrencyId,
-  toTransactionHash,
-} from '../utils/convert'
+import { toAddress, toCurrencyId, toTransactionHash } from '../utils/convert'
 import { signEIP712 } from '../utils/signature'
 import { approveCurrency } from './approveCurrency'
 
@@ -60,6 +55,7 @@ export type Bid = {
   /**
    * The address of the taker
    * @type Address
+   * @deprecated This parameter is not used anymore
    */
   taker?: Address
 
@@ -78,16 +74,7 @@ export type Bid = {
 
 export async function placeBid(
   sdk: Sdk,
-  {
-    chain,
-    collection,
-    token,
-    unitPrice,
-    quantity,
-    taker,
-    expiredAt,
-    metadata,
-  }: Bid,
+  { chain, collection, token, unitPrice, quantity, expiredAt, metadata }: Bid,
   signer: Signer,
   onProgress?: (state: State) => void,
 ): Promise<UUID> {
@@ -96,11 +83,12 @@ export async function placeBid(
   const offer: OfferInputBis = {
     type: 'BUY',
     makerAddress: toAddress(address),
-    assetId: toAssetId(chain, collection, token),
+    chainId: chain,
+    collectionAddress: collection,
+    tokenId: token,
     currencyId: toCurrencyId(chain, unitPrice.currency),
     unitPrice: BigNumber.from(unitPrice.amount).toString(),
     quantity: BigNumber.from(quantity || '1').toString(),
-    takerAddress: taker,
     expiredAt: expiredAt ? expiredAt.toISOString() : null,
     metadata: metadata,
   }


### PR DESCRIPTION
### Description

Replace `assetId` by `chainId`, `collectionAddress` and `tokenId`, and ignore `deprecate` in `listToken` and `placeBid`.

### Checklist

- [x] Update related changelogs <!-- Check [root's CHANGELOG.md](/CHANGELOG.md) to access the right changelogs -->