### PR TITLE
Change return payload of `createNFT` function

### DIFF
--- a/.changeset/mighty-numbers-kick.md
+++ b/.changeset/mighty-numbers-kick.md
@@ -2,4 +2,4 @@
 '@liteflow/react': major
 ---
 
-Change retun payload of createNFT function
+Change return payload of createNFT function

--- a/.changeset/mighty-numbers-kick.md
+++ b/.changeset/mighty-numbers-kick.md
@@ -1,0 +1,5 @@
+---
+'@liteflow/react': major
+---
+
+Change retun payload of createNFT function

--- a/docs/pages/tools/sdk-react/useCreateNFT.md
+++ b/docs/pages/tools/sdk-react/useCreateNFT.md
@@ -19,7 +19,7 @@ export default function Component() {
 
   const handleClick = async () => {
     const isLazyMinted = true
-    await createNFT(
+    const { chain, collection, token } = await createNFT(
       {
         chain: 1, // chainId of the network to mint on
         collection: '0x0000', // address of the collection to use
@@ -95,7 +95,7 @@ useCreateNFT(
         isAnimation: boolean
       }
     }
-  }, lazymint: boolean) => Promise<string>, // createNFT function
+  }, lazymint: boolean) => Promise<{ chain: ChainId; collection: Address; token: string }>, // createNFT function
   {
     activeStep: CreateNftStep, // steps of the NFT creation process
     transactionHash: string | undefined // returns the transaction hash after transaction has been placed on the blockchain

--- a/packages/core/src/utils/convert.ts
+++ b/packages/core/src/utils/convert.ts
@@ -12,14 +12,6 @@ export function toId(keys: (string | undefined | null)[]): string {
   return keys.filter(Boolean).join('-')
 }
 
-export function toAssetId(
-  chain: ChainId,
-  address: Address,
-  token: string,
-): string {
-  return toId([chain.toString(), address, token])
-}
-
 export function toCurrencyId(chain: ChainId, address: Address | null): string {
   return toId([chain.toString(), address])
 }

--- a/packages/react/src/useCreateNFT.ts
+++ b/packages/react/src/useCreateNFT.ts
@@ -1,5 +1,5 @@
 import { Signer, TypedDataSigner } from '@ethersproject/abstract-signer'
-import { Address, ChainId, TransactionHash, toAssetId } from '@liteflow/core'
+import { Address, ChainId, TransactionHash } from '@liteflow/core'
 import { useCallback, useContext, useState } from 'react'
 import invariant from 'ts-invariant'
 import { LiteflowContext } from './context'
@@ -33,7 +33,7 @@ type createNftFn = (
     }
   },
   lazymint: boolean,
-) => Promise<string>
+) => Promise<{ chain: ChainId; collection: Address; token: string }>
 
 export default function useCreateNFT(
   signer: (Signer & TypedDataSigner) | undefined,
@@ -111,7 +111,11 @@ export default function useCreateNFT(
               }
             },
           )
-          return toAssetId(asset.chain, asset.collection, asset.token)
+          return {
+            chain: asset.chain,
+            collection: asset.collection,
+            token: asset.token,
+          }
         }
 
         const asset = await client.asset.mint(
@@ -133,7 +137,11 @@ export default function useCreateNFT(
           },
         )
 
-        return toAssetId(asset.chain, asset.collection, asset.token)
+        return {
+          chain: asset.chain,
+          collection: asset.collection,
+          token: asset.token,
+        }
       } finally {
         setActiveProcess(CreateNftStep.INITIAL)
         setTransactionHash(undefined)


### PR DESCRIPTION
### Description

Based on https://github.com/liteflow-labs/liteflow-js/pull/226 to be able to remove `toAssetId` util function.

Change return payload of `createNFT` function.

In draft because this is a breaking change. To merge when we are ready to do breaking change.

### Checklist

- [x] Update related changelogs <!-- Check [root's CHANGELOG.md](/CHANGELOG.md) to access the right changelogs -->